### PR TITLE
Change how `extends` work

### DIFF
--- a/examples/simple/inheritance.cs
+++ b/examples/simple/inheritance.cs
@@ -1,0 +1,3 @@
+public interface A { public int PropA { get; set; } }
+public class B { public int PropB { get; set; } }
+public class C : B, A { public int PropA { get; set; } public int PropC { get; set; } }

--- a/src/LeanCode.ContractsGenerator.Tests/ExampleBased/Simple.cs
+++ b/src/LeanCode.ContractsGenerator.Tests/ExampleBased/Simple.cs
@@ -48,5 +48,35 @@ namespace LeanCode.ContractsGenerator.Tests.ExampleBased
                     .WithMember("B", 1)
                     .WithMember("C", 10);
         }
+
+        [Fact]
+        public void Inheritance_old()
+        {
+            "simple/inheritance.cs"
+                .Compiles()
+                .WithDto("A")
+                    .WithProperty("PropA", Known(KnownType.Int32))
+                .WithDto("B")
+                    .WithProperty("PropB", Known(KnownType.Int32))
+                .WithDto("C")
+                    .WithProperty("PropA", Known(KnownType.Int32))
+                    .WithProperty("PropB", Known(KnownType.Int32))
+                    .WithProperty("PropC", Known(KnownType.Int32));
+        }
+
+        [Fact]
+        public void Inheritance_proposed()
+        {
+            "simple/inheritance.cs"
+                .Compiles()
+                .WithDto("A")
+                    .WithProperty("PropA", Known(KnownType.Int32))
+                .WithDto("B")
+                    .WithProperty("PropB", Known(KnownType.Int32))
+                .WithDto("C")
+                    .WithProperty("PropC", Known(KnownType.Int32))
+                    .WithoutProperty("PropA")
+                    .WithoutProperty("PropB");
+        }
     }
 }

--- a/src/LeanCode.ContractsGenerator.Tests/ExampleBased/Simple.cs
+++ b/src/LeanCode.ContractsGenerator.Tests/ExampleBased/Simple.cs
@@ -50,22 +50,7 @@ namespace LeanCode.ContractsGenerator.Tests.ExampleBased
         }
 
         [Fact]
-        public void Inheritance_old()
-        {
-            "simple/inheritance.cs"
-                .Compiles()
-                .WithDto("A")
-                    .WithProperty("PropA", Known(KnownType.Int32))
-                .WithDto("B")
-                    .WithProperty("PropB", Known(KnownType.Int32))
-                .WithDto("C")
-                    .WithProperty("PropA", Known(KnownType.Int32))
-                    .WithProperty("PropB", Known(KnownType.Int32))
-                    .WithProperty("PropC", Known(KnownType.Int32));
-        }
-
-        [Fact]
-        public void Inheritance_proposed()
+        public void Inherited_properties()
         {
             "simple/inheritance.cs"
                 .Compiles()


### PR DESCRIPTION
## Proposal
Recently, it came to my attention that clients don't really like the way `Extends` is structured - i.e. the type that we're describing has all the properties of parent (in the meaning - the ones that are extended) types.

Consider this code:
```csharp
public interface A { public int PropA { get; set; } }
public class B { public int PropB { get; set; } }
public class C : B, A { public int PropA { get; set; } public int PropC { get; set; } }
```

In the "old" way, the `C` type would have these properties: `PropA` (implemented directly, but required by the interface), `PropB` (inherited from `B`) and `PropC`. 

In the "new" way, the `C` type would have only `PropC` because it is directly implemented by the type. `PropA` and `PropB` are described in up in the chain.

## Reasoning
The old way `Extended` worked was more like interfaces. This is quite awkward considering this is mostly _data_ protocol, not programming language. The new way works more like mixins/multi-inheritance, which seems to be easier to reason about and implement in client languages (TS specifically).

This solution also does not prevent clients from generating types that are really a sum of extended types. It only needs a little bit more code as the union needs to be handled there.

The "old" solution also allows clients to work like this, but it is more cumbersome - instead of doing union, you need to exclude properties from all the types that are being extended. It is easier to do on the `server` side, hence the change.

## Problems
Roslyn, unfortunately, does not give us information that the `IPropertySymbol` is required by/connected to an interface. We need to do the resolution logic ourselves (or is there a way in Roslyn and I just can't find it?). IMO this is not really a problem, as the logic is quite easy (just a name match), but we need to disallow explicit interface implementations (which I would opt to do anyway).

## Next steps
Considering that I am not really confident which of these two is better - what are your thoughts?

## Notes
This is a draft PR not only because I don't know which way to choose, but also the code needs some improvements.