### PR TITLE
Analyzers

### DIFF
--- a/examples/analyzers/context.cs
+++ b/examples/analyzers/context.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using LeanCode.CQRS;
+using LeanCode.CQRS.Security;
+
+public class Inner<T> { }
+
+public class Dto1 { public Inner<decimal> A { get; set; } }
+public class Dto2 { public List<decimal> A { get; set; } }
+public class Dto3 : System.IDisposable { public void Dispose() { } }
+[AllowUnauthorized] public class Query1 : IRemoteQuery<decimal> { }
+[AllowUnauthorized] public class Query2 : IRemoteQuery<Inner<decimal>> { }

--- a/examples/analyzers/context.cs
+++ b/examples/analyzers/context.cs
@@ -7,5 +7,8 @@ public class Inner<T> { }
 public class Dto1 { public Inner<decimal> A { get; set; } }
 public class Dto2 { public List<decimal> A { get; set; } }
 public class Dto3 : System.IDisposable { public void Dispose() { } }
+public class Dto4 : Inner<int>, System.IDisposable { public void Dispose() { } }
+public class Dto5 : Inner<decimal> { }
+public class Dto6 : Inner<Inner<decimal>> { }
 [AllowUnauthorized] public class Query1 : IRemoteQuery<decimal> { }
 [AllowUnauthorized] public class Query2 : IRemoteQuery<Inner<decimal>> { }

--- a/examples/analyzers/error_codes.cs
+++ b/examples/analyzers/error_codes.cs
@@ -1,0 +1,31 @@
+using LeanCode.CQRS;
+using LeanCode.CQRS.Security;
+
+public class Dto
+{
+    public abstract class ErrorCodes
+    {
+        public const int A = 100;
+        public const int B = 101;
+    }
+}
+
+[AllowUnauthorized]
+public class Cmd1 : IRemoteCommand
+{
+    public static class ErrorCodes
+    {
+        public const int A = 1;
+        public const int B = 1;
+    }
+}
+
+[AllowUnauthorized]
+public class Cmd2 : IRemoteCommand
+{
+    public static class ErrorCodes
+    {
+        public const int Dup = 100;
+        public class Inner : Dto.ErrorCodes { }
+    }
+}

--- a/examples/analyzers/external_types.cs
+++ b/examples/analyzers/external_types.cs
@@ -1,6 +1,11 @@
+using LeanCode.CQRS;
+using LeanCode.CQRS.Security;
+
 public class Dto
 {
     public decimal Wrong1 { get; set; }
     public System.Half Wrong2 { get; set; }
     public LeanCode.CQRS.ExcludeFromContractsGenerationAttribute Wrong3 { get; set; }
 }
+
+[AllowUnauthorized] public class Query : IRemoteQuery<decimal> { }

--- a/examples/analyzers/external_types.cs
+++ b/examples/analyzers/external_types.cs
@@ -1,0 +1,6 @@
+public class Dto
+{
+    public decimal Wrong1 { get; set; }
+    public System.Half Wrong2 { get; set; }
+    public LeanCode.CQRS.ExcludeFromContractsGenerationAttribute Wrong3 { get; set; }
+}

--- a/src/LeanCode.ContractsGenerator.Tests/ExampleBased/Analyzers/Context.cs
+++ b/src/LeanCode.ContractsGenerator.Tests/ExampleBased/Analyzers/Context.cs
@@ -12,6 +12,9 @@ public class Context
                 .WithError("CNTR0004", "Dto1.A<0: System.Decimal>")
                 .WithError("CNTR0004", "Dto2.A<0: System.Decimal>")
                 .WithError("CNTR0004", "Dto3:System.IDisposable")
+                .WithError("CNTR0004", "Dto4:System.IDisposable")
+                .WithError("CNTR0004", "Dto5:Inner<0: System.Decimal>")
+                .WithError("CNTR0004", "Dto6:Inner<0: Inner><0: System.Decimal>")
                 .WithError("CNTR0004", "Query1->System.Decimal")
                 .WithError("CNTR0004", "Query2->Inner<0: System.Decimal>");
     }

--- a/src/LeanCode.ContractsGenerator.Tests/ExampleBased/Analyzers/Context.cs
+++ b/src/LeanCode.ContractsGenerator.Tests/ExampleBased/Analyzers/Context.cs
@@ -1,0 +1,18 @@
+using Xunit;
+
+namespace LeanCode.ContractsGenerator.Tests.ExampleBased.Analyzers;
+
+public class Context
+{
+    [Fact]
+    public void Context_is_tracked_correctly()
+    {
+        "analyzers/context.cs"
+            .AnalyzeFails()
+                .WithError("CNTR0004", "Dto1.A<0: System.Decimal>")
+                .WithError("CNTR0004", "Dto2.A<0: System.Decimal>")
+                .WithError("CNTR0004", "Dto3:System.IDisposable")
+                .WithError("CNTR0004", "Query1->System.Decimal")
+                .WithError("CNTR0004", "Query2->Inner<0: System.Decimal>");
+    }
+}

--- a/src/LeanCode.ContractsGenerator.Tests/ExampleBased/Analyzers/ErrorCodes.cs
+++ b/src/LeanCode.ContractsGenerator.Tests/ExampleBased/Analyzers/ErrorCodes.cs
@@ -1,0 +1,16 @@
+using Xunit;
+
+namespace LeanCode.ContractsGenerator.Tests.ExampleBased.Analyzers
+{
+    public class ErrorCodes
+    {
+        [Fact]
+        public void Duplicated_error_codes_in_command_are_detected()
+        {
+            "analyzers/error_codes.cs"
+                .AnalyzeFails()
+                    .WithError("LNCD003", "Cmd1")
+                    .WithError("LNCD003", "Cmd2");
+        }
+    }
+}

--- a/src/LeanCode.ContractsGenerator.Tests/ExampleBased/Analyzers/ErrorCodes.cs
+++ b/src/LeanCode.ContractsGenerator.Tests/ExampleBased/Analyzers/ErrorCodes.cs
@@ -1,16 +1,15 @@
 using Xunit;
 
-namespace LeanCode.ContractsGenerator.Tests.ExampleBased.Analyzers
+namespace LeanCode.ContractsGenerator.Tests.ExampleBased.Analyzers;
+
+public class ErrorCodes
 {
-    public class ErrorCodes
+    [Fact]
+    public void Duplicated_error_codes_in_command_are_detected()
     {
-        [Fact]
-        public void Duplicated_error_codes_in_command_are_detected()
-        {
-            "analyzers/error_codes.cs"
-                .AnalyzeFails()
-                    .WithError("CNTR0003", "Cmd1.ErrorCodes")
-                    .WithError("CNTR0003", "Cmd2.ErrorCodes");
-        }
+        "analyzers/error_codes.cs"
+            .AnalyzeFails()
+                .WithError("CNTR0003", "Cmd1.ErrorCodes")
+                .WithError("CNTR0003", "Cmd2.ErrorCodes");
     }
 }

--- a/src/LeanCode.ContractsGenerator.Tests/ExampleBased/Analyzers/ErrorCodes.cs
+++ b/src/LeanCode.ContractsGenerator.Tests/ExampleBased/Analyzers/ErrorCodes.cs
@@ -9,8 +9,8 @@ namespace LeanCode.ContractsGenerator.Tests.ExampleBased.Analyzers
         {
             "analyzers/error_codes.cs"
                 .AnalyzeFails()
-                    .WithError("LNCD003", "Cmd1")
-                    .WithError("LNCD003", "Cmd2");
+                    .WithError("CNTR0003", "Cmd1.ErrorCodes")
+                    .WithError("CNTR0003", "Cmd2.ErrorCodes");
         }
     }
 }

--- a/src/LeanCode.ContractsGenerator.Tests/ExampleBased/Analyzers/ExternalType.cs
+++ b/src/LeanCode.ContractsGenerator.Tests/ExampleBased/Analyzers/ExternalType.cs
@@ -9,8 +9,10 @@ public class ExternalType
     {
         "analyzers/external_types.cs"
             .AnalyzeFails()
+                .WithErrorNumber(4)
                 .WithError("CNTR0004", "Dto.Wrong1")
                 .WithError("CNTR0004", "Dto.Wrong2")
-                .WithError("CNTR0004", "Dto.Wrong3");
+                .WithError("CNTR0004", "Dto.Wrong3")
+                .WithError("CNTR0004", "Query->System.Decimal");
     }
 }

--- a/src/LeanCode.ContractsGenerator.Tests/ExampleBased/Analyzers/ExternalType.cs
+++ b/src/LeanCode.ContractsGenerator.Tests/ExampleBased/Analyzers/ExternalType.cs
@@ -1,0 +1,16 @@
+using Xunit;
+
+namespace LeanCode.ContractsGenerator.Tests.ExampleBased.Analyzers;
+
+public class ExternalType
+{
+    [Fact]
+    public void External_types_are_reported_as_errors()
+    {
+        "analyzers/external_types.cs"
+            .AnalyzeFails()
+                .WithError("CNTR0004", "Dto.Wrong1")
+                .WithError("CNTR0004", "Dto.Wrong2")
+                .WithError("CNTR0004", "Dto.Wrong3");
+    }
+}

--- a/src/LeanCode.ContractsGenerator.Tests/ExampleBasedAsserts.cs
+++ b/src/LeanCode.ContractsGenerator.Tests/ExampleBasedAsserts.cs
@@ -82,9 +82,9 @@ public static class ExampleBasedAsserts
         return errors;
     }
 
-    public static AssertedErrors WithError(this AssertedErrors errors, string code, string name)
+    public static AssertedErrors WithError(this AssertedErrors errors, string code, string path)
     {
-        Assert.Contains(errors.Errors, e => e.Code == code && e.Name == name);
+        Assert.Contains(errors.Errors, e => e.Code == code && e.Context.Path == path);
         return errors;
     }
 

--- a/src/LeanCode.ContractsGenerator.Tests/ExampleBasedAsserts.cs
+++ b/src/LeanCode.ContractsGenerator.Tests/ExampleBasedAsserts.cs
@@ -88,6 +88,12 @@ public static class ExampleBasedAsserts
         return errors;
     }
 
+    public static AssertedErrors WithErrorNumber(this AssertedErrors errors, int count)
+    {
+        Assert.Equal(count, errors.Errors.Count);
+        return errors;
+    }
+
     public static AssertedQuery WithReturnType(this AssertedQuery stmt, TypeRef typeRef)
     {
         Assert.Equal(typeRef, stmt.Statement.Query.ReturnType);

--- a/src/LeanCode.ContractsGenerator.Tests/ExampleBasedAsserts.cs
+++ b/src/LeanCode.ContractsGenerator.Tests/ExampleBasedAsserts.cs
@@ -76,6 +76,18 @@ public static class ExampleBasedAsserts
         return stmt;
     }
 
+    public static AssertedErrors WithError(this AssertedErrors errors, string code)
+    {
+        Assert.Contains(errors.Errors, e => e.Code == code);
+        return errors;
+    }
+
+    public static AssertedErrors WithError(this AssertedErrors errors, string code, string name)
+    {
+        Assert.Contains(errors.Errors, e => e.Code == code && e.Name == name);
+        return errors;
+    }
+
     public static AssertedQuery WithReturnType(this AssertedQuery stmt, TypeRef typeRef)
     {
         Assert.Equal(typeRef, stmt.Statement.Query.ReturnType);
@@ -200,3 +212,5 @@ public record AssertedDto(Export Export, Statement Statement, TypeDescriptor Des
 public record AssertedEnum(Export Export, Statement Statement) : AssertedStatement(Export, Statement);
 
 public record AssertedProperty(PropertyRef Property);
+
+public record AssertedErrors(IReadOnlyList<AnalyzeError> Errors);

--- a/src/LeanCode.ContractsGenerator.Tests/ExampleBasedHelpers.cs
+++ b/src/LeanCode.ContractsGenerator.Tests/ExampleBasedHelpers.cs
@@ -12,6 +12,14 @@ public static class ExampleBasedHelpers
         return new(new ContractsGenerator.Generation.ContractsGenerator(compiled).Generate());
     }
 
+    public static AssertedErrors AnalyzeFails(this string path)
+    {
+        var code = File.ReadAllText(Path.Join("examples", path));
+        var compiled = ContractsCompiler.CompileCode(code, "test");
+        var ex = Xunit.Assert.Throws<AnalyzeFailedException>(() => new ContractsGenerator.Generation.ContractsGenerator(compiled).Generate());
+        return new(ex.Errors);
+    }
+
     public static AssertedExport ProjectCompiles(this string path)
     {
         return ProjectsCompile(path);

--- a/src/LeanCode.ContractsGenerator/AnalyzeFailedException.cs
+++ b/src/LeanCode.ContractsGenerator/AnalyzeFailedException.cs
@@ -1,0 +1,13 @@
+namespace LeanCode.ContractsGenerator
+{
+    public class AnalyzeFailedException : Exception
+    {
+        public IReadOnlyList<AnalyzeError> Errors { get; }
+
+        public AnalyzeFailedException(IReadOnlyList<AnalyzeError> errors)
+            : base("Analyze phase failed.")
+        {
+            Errors = errors;
+        }
+    }
+}

--- a/src/LeanCode.ContractsGenerator/AnalyzeFailedException.cs
+++ b/src/LeanCode.ContractsGenerator/AnalyzeFailedException.cs
@@ -1,13 +1,12 @@
-namespace LeanCode.ContractsGenerator
-{
-    public class AnalyzeFailedException : Exception
-    {
-        public IReadOnlyList<AnalyzeError> Errors { get; }
+namespace LeanCode.ContractsGenerator;
 
-        public AnalyzeFailedException(IReadOnlyList<AnalyzeError> errors)
-            : base("Analyze phase failed.")
-        {
-            Errors = errors;
-        }
+public class AnalyzeFailedException : Exception
+{
+    public IReadOnlyList<AnalyzeError> Errors { get; }
+
+    public AnalyzeFailedException(IReadOnlyList<AnalyzeError> errors)
+        : base("Analyze phase failed.")
+    {
+        Errors = errors;
     }
 }

--- a/src/LeanCode.ContractsGenerator/AnalyzerContext.cs
+++ b/src/LeanCode.ContractsGenerator/AnalyzerContext.cs
@@ -1,0 +1,127 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace LeanCode.ContractsGenerator;
+
+public enum PathMarker
+{
+    Argument,
+    Attribute,
+    GenericParameter,
+    Extends,
+    ReturnType,
+    ErrorCodes,
+}
+
+[SuppressMessage("?", "SA1313", Justification = "False positive.")]
+public readonly record struct AnalyzerContext(string Path)
+{
+    public static readonly AnalyzerContext Empty = new("");
+
+    public AnalyzerContext Descend(AttributeRef attrRef)
+    {
+        return Descend(attrRef.AttributeName);
+    }
+
+    public AnalyzerContext Descend(Statement stmt)
+    {
+        return Descend(stmt.Name);
+    }
+
+    public AnalyzerContext Descend(EnumValue e)
+    {
+        return Descend(e.Name);
+    }
+
+    public AnalyzerContext Descend(GenericParameter g)
+    {
+        return Descend(g.Name);
+    }
+
+    public AnalyzerContext Descend(PropertyRef propRef)
+    {
+        return Descend(propRef.Name);
+    }
+
+    public AnalyzerContext Descend(ConstantRef constRef)
+    {
+        return Descend(constRef.Name);
+    }
+
+    public AnalyzerContext Marked(PathMarker marker)
+    {
+        return marker switch
+        {
+            PathMarker.Argument => Descend("`Arg`"),
+            PathMarker.Attribute => Descend("`Attr`"),
+            PathMarker.GenericParameter => Descend("`Generic`"),
+            PathMarker.Extends => Descend("`Extends`"),
+            PathMarker.ReturnType => Descend("`Return`"),
+            PathMarker.ErrorCodes => Descend("ErrorCodes"),
+            _ => this,
+        };
+    }
+
+    public AnalyzerContext Descend(TypeRef typeRef)
+    {
+        if (typeRef.Internal is TypeRef.Types.Internal i)
+        {
+            return Descend(i.Name);
+        }
+        else if (typeRef.Known is TypeRef.Types.Known k)
+        {
+            return Descend(k.Type.ToString());
+        }
+        else if (typeRef.Generic is TypeRef.Types.Generic g)
+        {
+            return Descend(g.Name);
+        }
+        else
+        {
+            return this;
+        }
+    }
+
+    public AnalyzerContext Descend(AttributeArgument arg)
+    {
+        if (arg.Positional is AttributeArgument.Types.Positional p)
+        {
+            return Descend(p.Position.ToString());
+        }
+        else if (arg.Named is AttributeArgument.Types.Named n)
+        {
+            return Descend(n.Name);
+        }
+        else
+        {
+            return this;
+        }
+    }
+
+    public AnalyzerContext Descend(ErrorCode errCode)
+    {
+        if (errCode.Group is ErrorCode.Types.Group g)
+        {
+            return Descend(g.Name);
+        }
+        else if (errCode.Single is ErrorCode.Types.Single s)
+        {
+            return Descend(s.Name);
+        }
+        else
+        {
+            return this;
+        }
+    }
+
+    private AnalyzerContext Descend(string nextName)
+    {
+        if (this == Empty)
+        {
+            return new(nextName);
+        }
+        else
+        {
+            return new($"{Path}.{nextName}");
+        }
+    }
+}

--- a/src/LeanCode.ContractsGenerator/Analyzers/AllAnalyzers.cs
+++ b/src/LeanCode.ContractsGenerator/Analyzers/AllAnalyzers.cs
@@ -1,0 +1,17 @@
+namespace LeanCode.ContractsGenerator.Analyzers
+{
+    public class AllAnalyzers : IAnalyzer
+    {
+        private static readonly IReadOnlyList<IAnalyzer> Analyzers = new IAnalyzer[]
+        {
+            new InternalStructureCheck(),
+            new KnownTypeCheck(),
+            new ErrorCodesUniqueness(),
+        };
+
+        public IEnumerable<AnalyzeError> Analyze(Export export)
+        {
+            return Analyzers.SelectMany(a => a.Analyze(export));
+        }
+    }
+}

--- a/src/LeanCode.ContractsGenerator/Analyzers/AllAnalyzers.cs
+++ b/src/LeanCode.ContractsGenerator/Analyzers/AllAnalyzers.cs
@@ -4,9 +4,10 @@ public class AllAnalyzers : IAnalyzer
 {
     private static readonly IReadOnlyList<IAnalyzer> Analyzers = new IAnalyzer[]
     {
-            new InternalStructureCheck(),
-            new KnownTypeCheck(),
-            new ErrorCodesUniqueness(),
+        new InternalStructureCheck(),
+        new KnownTypeCheck(),
+        new ErrorCodesUniqueness(),
+        new ExternalTypeCheck(),
     };
 
     public IEnumerable<AnalyzeError> Analyze(Export export)

--- a/src/LeanCode.ContractsGenerator/Analyzers/AllAnalyzers.cs
+++ b/src/LeanCode.ContractsGenerator/Analyzers/AllAnalyzers.cs
@@ -1,17 +1,16 @@
-namespace LeanCode.ContractsGenerator.Analyzers
+namespace LeanCode.ContractsGenerator.Analyzers;
+
+public class AllAnalyzers : IAnalyzer
 {
-    public class AllAnalyzers : IAnalyzer
+    private static readonly IReadOnlyList<IAnalyzer> Analyzers = new IAnalyzer[]
     {
-        private static readonly IReadOnlyList<IAnalyzer> Analyzers = new IAnalyzer[]
-        {
             new InternalStructureCheck(),
             new KnownTypeCheck(),
             new ErrorCodesUniqueness(),
-        };
+    };
 
-        public IEnumerable<AnalyzeError> Analyze(Export export)
-        {
-            return Analyzers.SelectMany(a => a.Analyze(export));
-        }
+    public IEnumerable<AnalyzeError> Analyze(Export export)
+    {
+        return Analyzers.SelectMany(a => a.Analyze(export));
     }
 }

--- a/src/LeanCode.ContractsGenerator/Analyzers/BaseAnalyzer.cs
+++ b/src/LeanCode.ContractsGenerator/Analyzers/BaseAnalyzer.cs
@@ -148,6 +148,16 @@ public class BaseAnalyzer : IAnalyzer
             .Concat(descr.Constants.SelectMany(c => AnalyzeConstantRef(context.Descend(c), c)));
     }
 
+    public virtual IEnumerable<AnalyzeError> AnalyzeTypeDescriptorForQuery(AnalyzerContext context, TypeDescriptor descr)
+    {
+        return descr.Extends
+            .Where(e => e.Known is null || e.Known.Type != KnownType.Query) // Exclude `Query` type, as it will be checked by the `Return` check
+            .SelectMany(t => AnalyzeTypeRef(context.Extends(t), t))
+            .Concat(descr.GenericParameters.SelectMany((g, i) => AnalyzeGenericParameter(context.GenericParameter(i, g), g)))
+            .Concat(descr.Properties.SelectMany(p => AnalyzePropertyRef(context.Descend(p), p)))
+            .Concat(descr.Constants.SelectMany(c => AnalyzeConstantRef(context.Descend(c), c)));
+    }
+
     public virtual IEnumerable<AnalyzeError> AnalyzeDTO(AnalyzerContext context, Statement stmt, Statement.Types.DTO dto)
     {
         return AnalyzeTypeDescriptor(context, dto.TypeDescriptor);
@@ -160,7 +170,7 @@ public class BaseAnalyzer : IAnalyzer
 
     public virtual IEnumerable<AnalyzeError> AnalyzeQuery(AnalyzerContext context, Statement stmt, Statement.Types.Query query)
     {
-        return AnalyzeTypeDescriptor(context, query.TypeDescriptor)
+        return AnalyzeTypeDescriptorForQuery(context, query.TypeDescriptor)
             .Concat(AnalyzeTypeRef(context.Returns(query.ReturnType), query.ReturnType));
     }
 

--- a/src/LeanCode.ContractsGenerator/Analyzers/BaseAnalyzer.cs
+++ b/src/LeanCode.ContractsGenerator/Analyzers/BaseAnalyzer.cs
@@ -4,51 +4,52 @@ public class BaseAnalyzer : IAnalyzer
 {
     public virtual IEnumerable<AnalyzeError> Analyze(Export export)
     {
+        var context = AnalyzerContext.Empty;
         return export.Statements
-            .SelectMany(AnalyzeStatement)
+            .SelectMany(s => AnalyzeStatement(context.Descend(s), s))
             .ToList();
     }
 
-    public virtual IEnumerable<AnalyzeError> AnalyzeKnownType(KnownType knownType)
+    public virtual IEnumerable<AnalyzeError> AnalyzeKnownType(AnalyzerContext context, KnownType knownType)
     {
         return Enumerable.Empty<AnalyzeError>();
     }
 
-    public virtual IEnumerable<AnalyzeError> AnalyzeValueRef(ValueRef knownType)
+    public virtual IEnumerable<AnalyzeError> AnalyzeValueRef(AnalyzerContext context, ValueRef knownType)
     {
         return Enumerable.Empty<AnalyzeError>();
     }
 
-    public virtual IEnumerable<AnalyzeError> AnalyzeGenericTypeRef(TypeRef typeRef, TypeRef.Types.Generic g)
+    public virtual IEnumerable<AnalyzeError> AnalyzeGenericTypeRef(AnalyzerContext context, TypeRef typeRef, TypeRef.Types.Generic g)
     {
         return Enumerable.Empty<AnalyzeError>();
     }
 
-    public virtual IEnumerable<AnalyzeError> AnalyzeInternalTypeRef(TypeRef typeRef, TypeRef.Types.Internal i)
+    public virtual IEnumerable<AnalyzeError> AnalyzeInternalTypeRef(AnalyzerContext context, TypeRef typeRef, TypeRef.Types.Internal i)
     {
-        return i.Arguments.SelectMany(AnalyzeTypeRef);
+        return i.Arguments.SelectMany(a => AnalyzeTypeRef(context.Marked(PathMarker.Argument).Descend(a), a));
     }
 
-    public virtual IEnumerable<AnalyzeError> AnalyzeKnownTypeRef(TypeRef typeRef, TypeRef.Types.Known k)
+    public virtual IEnumerable<AnalyzeError> AnalyzeKnownTypeRef(AnalyzerContext context, TypeRef typeRef, TypeRef.Types.Known k)
     {
         return k.Arguments
-            .SelectMany(AnalyzeTypeRef)
-            .Concat(AnalyzeKnownType(k.Type));
+            .SelectMany(r => AnalyzeTypeRef(context.Marked(PathMarker.Argument).Descend(r), r))
+            .Concat(AnalyzeKnownType(context, k.Type));
     }
 
-    public virtual IEnumerable<AnalyzeError> AnalyzeTypeRef(TypeRef typeRef)
+    public virtual IEnumerable<AnalyzeError> AnalyzeTypeRef(AnalyzerContext context, TypeRef typeRef)
     {
         if (typeRef.Internal is TypeRef.Types.Internal i)
         {
-            return AnalyzeInternalTypeRef(typeRef, i);
+            return AnalyzeInternalTypeRef(context, typeRef, i);
         }
         else if (typeRef.Known is TypeRef.Types.Known k)
         {
-            return AnalyzeKnownTypeRef(typeRef, k);
+            return AnalyzeKnownTypeRef(context, typeRef, k);
         }
         else if (typeRef.Generic is TypeRef.Types.Generic g)
         {
-            return AnalyzeGenericTypeRef(typeRef, g);
+            return AnalyzeGenericTypeRef(context, typeRef, g);
         }
         else
         {
@@ -56,30 +57,30 @@ public class BaseAnalyzer : IAnalyzer
         }
     }
 
-    public virtual IEnumerable<AnalyzeError> AnalyzeGenericParameter(GenericParameter genericParam)
+    public virtual IEnumerable<AnalyzeError> AnalyzeGenericParameter(AnalyzerContext context, GenericParameter genericParam)
     {
         return Enumerable.Empty<AnalyzeError>();
     }
 
-    public virtual IEnumerable<AnalyzeError> AnalyzePositionalAttributeArgument(AttributeArgument arg, AttributeArgument.Types.Positional p)
+    public virtual IEnumerable<AnalyzeError> AnalyzePositionalAttributeArgument(AnalyzerContext context, AttributeArgument arg, AttributeArgument.Types.Positional p)
     {
-        return AnalyzeValueRef(p.Value);
+        return AnalyzeValueRef(context, p.Value);
     }
 
-    public virtual IEnumerable<AnalyzeError> AnalyzeNamedAttributeArgument(AttributeArgument arg, AttributeArgument.Types.Named n)
+    public virtual IEnumerable<AnalyzeError> AnalyzeNamedAttributeArgument(AnalyzerContext context, AttributeArgument arg, AttributeArgument.Types.Named n)
     {
-        return AnalyzeValueRef(n.Value);
+        return AnalyzeValueRef(context, n.Value);
     }
 
-    public virtual IEnumerable<AnalyzeError> AnalyzeAttributeArgument(AttributeArgument arg)
+    public virtual IEnumerable<AnalyzeError> AnalyzeAttributeArgument(AnalyzerContext context, AttributeArgument arg)
     {
         if (arg.Positional is AttributeArgument.Types.Positional p)
         {
-            return AnalyzePositionalAttributeArgument(arg, p);
+            return AnalyzePositionalAttributeArgument(context, arg, p);
         }
         else if (arg.Named is AttributeArgument.Types.Named n)
         {
-            return AnalyzeNamedAttributeArgument(arg, n);
+            return AnalyzeNamedAttributeArgument(context, arg, n);
         }
         else
         {
@@ -87,46 +88,46 @@ public class BaseAnalyzer : IAnalyzer
         }
     }
 
-    public virtual IEnumerable<AnalyzeError> AnalyzeAttributeRef(AttributeRef attrRef)
+    public virtual IEnumerable<AnalyzeError> AnalyzeAttributeRef(AnalyzerContext context, AttributeRef attrRef)
     {
-        return attrRef.Argument.SelectMany(AnalyzeAttributeArgument);
+        return attrRef.Argument.SelectMany(a => AnalyzeAttributeArgument(context.Marked(PathMarker.Argument).Descend(a), a));
     }
 
-    public virtual IEnumerable<AnalyzeError> AnalyzePropertyRef(PropertyRef propRef)
+    public virtual IEnumerable<AnalyzeError> AnalyzePropertyRef(AnalyzerContext context, PropertyRef propRef)
     {
-        return AnalyzeTypeRef(propRef.Type)
-            .Concat(propRef.Attributes.SelectMany(AnalyzeAttributeRef));
+        return AnalyzeTypeRef(context, propRef.Type)
+            .Concat(propRef.Attributes.SelectMany(a => AnalyzeAttributeRef(context.Marked(PathMarker.Attribute).Descend(a), a)));
     }
 
-    public virtual IEnumerable<AnalyzeError> AnalyzeConstantRef(ConstantRef constant)
+    public virtual IEnumerable<AnalyzeError> AnalyzeConstantRef(AnalyzerContext context, ConstantRef constant)
     {
-        return AnalyzeValueRef(constant.Value);
+        return AnalyzeValueRef(context, constant.Value);
     }
 
-    public virtual IEnumerable<AnalyzeError> AnalyzeEnumValue(EnumValue enumVal)
-    {
-        return Enumerable.Empty<AnalyzeError>();
-    }
-
-    public virtual IEnumerable<AnalyzeError> AnalyzeGroupErrorCode(ErrorCode errCode, ErrorCode.Types.Group g)
-    {
-        return AnalyzeErrorCodes(g.InnerCodes);
-    }
-
-    public virtual IEnumerable<AnalyzeError> AnalyzeSingleErrorCode(ErrorCode errCode, ErrorCode.Types.Single s)
+    public virtual IEnumerable<AnalyzeError> AnalyzeEnumValue(AnalyzerContext context, EnumValue enumVal)
     {
         return Enumerable.Empty<AnalyzeError>();
     }
 
-    public virtual IEnumerable<AnalyzeError> AnalyzeErrorCode(ErrorCode errCode)
+    public virtual IEnumerable<AnalyzeError> AnalyzeGroupErrorCode(AnalyzerContext context, ErrorCode errCode, ErrorCode.Types.Group g)
+    {
+        return AnalyzeErrorCodes(context, g.InnerCodes);
+    }
+
+    public virtual IEnumerable<AnalyzeError> AnalyzeSingleErrorCode(AnalyzerContext context, ErrorCode errCode, ErrorCode.Types.Single s)
+    {
+        return Enumerable.Empty<AnalyzeError>();
+    }
+
+    public virtual IEnumerable<AnalyzeError> AnalyzeErrorCode(AnalyzerContext context, ErrorCode errCode)
     {
         if (errCode.Group is ErrorCode.Types.Group g)
         {
-            return AnalyzeGroupErrorCode(errCode, g);
+            return AnalyzeGroupErrorCode(context, errCode, g);
         }
         else if (errCode.Single is ErrorCode.Types.Single s)
         {
-            return AnalyzeSingleErrorCode(errCode, s);
+            return AnalyzeSingleErrorCode(context, errCode, s);
         }
         else
         {
@@ -134,63 +135,63 @@ public class BaseAnalyzer : IAnalyzer
         }
     }
 
-    public virtual IEnumerable<AnalyzeError> AnalyzeErrorCodes(IEnumerable<ErrorCode> errCodes)
+    public virtual IEnumerable<AnalyzeError> AnalyzeErrorCodes(AnalyzerContext context, IEnumerable<ErrorCode> errCodes)
     {
-        return errCodes.SelectMany(AnalyzeErrorCode);
+        return errCodes.SelectMany(e => AnalyzeErrorCode(context.Descend(e), e));
     }
 
-    public virtual IEnumerable<AnalyzeError> AnalyzeTypeDescriptor(TypeDescriptor descr)
+    public virtual IEnumerable<AnalyzeError> AnalyzeTypeDescriptor(AnalyzerContext context, TypeDescriptor descr)
     {
-        return descr.Extends.SelectMany(AnalyzeTypeRef)
-            .Concat(descr.GenericParameters.SelectMany(AnalyzeGenericParameter))
-            .Concat(descr.Properties.SelectMany(AnalyzePropertyRef))
-            .Concat(descr.Constants.SelectMany(AnalyzeConstantRef));
+        return descr.Extends.SelectMany(t => AnalyzeTypeRef(context.Marked(PathMarker.Extends).Descend(t), t))
+            .Concat(descr.GenericParameters.SelectMany(g => AnalyzeGenericParameter(context.Marked(PathMarker.GenericParameter).Descend(g), g)))
+            .Concat(descr.Properties.SelectMany(p => AnalyzePropertyRef(context.Descend(p), p)))
+            .Concat(descr.Constants.SelectMany(c => AnalyzeConstantRef(context.Descend(c), c)));
     }
 
-    public virtual IEnumerable<AnalyzeError> AnalyzeDTO(Statement stmt, Statement.Types.DTO dto)
+    public virtual IEnumerable<AnalyzeError> AnalyzeDTO(AnalyzerContext context, Statement stmt, Statement.Types.DTO dto)
     {
-        return AnalyzeTypeDescriptor(dto.TypeDescriptor);
+        return AnalyzeTypeDescriptor(context, dto.TypeDescriptor);
     }
 
-    public virtual IEnumerable<AnalyzeError> AnalyzeEnum(Statement stmt, Statement.Types.Enum @enum)
+    public virtual IEnumerable<AnalyzeError> AnalyzeEnum(AnalyzerContext context, Statement stmt, Statement.Types.Enum @enum)
     {
-        return @enum.Members.SelectMany(AnalyzeEnumValue);
+        return @enum.Members.SelectMany(m => AnalyzeEnumValue(context.Descend(m), m));
     }
 
-    public virtual IEnumerable<AnalyzeError> AnalyzeQuery(Statement stmt, Statement.Types.Query query)
+    public virtual IEnumerable<AnalyzeError> AnalyzeQuery(AnalyzerContext context, Statement stmt, Statement.Types.Query query)
     {
-        return AnalyzeTypeDescriptor(query.TypeDescriptor)
-            .Concat(AnalyzeTypeRef(query.ReturnType));
+        return AnalyzeTypeDescriptor(context, query.TypeDescriptor)
+            .Concat(AnalyzeTypeRef(context.Marked(PathMarker.ReturnType), query.ReturnType));
     }
 
-    public virtual IEnumerable<AnalyzeError> AnalyzeCommand(Statement stmt, Statement.Types.Command command)
+    public virtual IEnumerable<AnalyzeError> AnalyzeCommand(AnalyzerContext context, Statement stmt, Statement.Types.Command command)
     {
-        return AnalyzeTypeDescriptor(command.TypeDescriptor)
-            .Concat(AnalyzeErrorCodes(command.ErrorCodes));
+        return AnalyzeTypeDescriptor(context, command.TypeDescriptor)
+            .Concat(AnalyzeErrorCodes(context.Marked(PathMarker.ErrorCodes), command.ErrorCodes));
     }
 
-    public virtual IEnumerable<AnalyzeError> AnalyzeStatement(Statement stmt)
+    public virtual IEnumerable<AnalyzeError> AnalyzeStatement(AnalyzerContext context, Statement stmt)
     {
-        return AnalyzeInner(stmt)
-            .Concat(stmt.Attributes.SelectMany(AnalyzeAttributeRef));
+        return AnalyzeInner(context, stmt)
+            .Concat(stmt.Attributes.SelectMany(a => AnalyzeAttributeRef(context.Marked(PathMarker.Attribute).Descend(a), a)));
 
-        IEnumerable<AnalyzeError> AnalyzeInner(Statement stmt)
+        IEnumerable<AnalyzeError> AnalyzeInner(AnalyzerContext context, Statement stmt)
         {
             if (stmt.Dto is Statement.Types.DTO dto)
             {
-                return AnalyzeDTO(stmt, dto);
+                return AnalyzeDTO(context, stmt, dto);
             }
             else if (stmt.Enum is Statement.Types.Enum @enum)
             {
-                return AnalyzeEnum(stmt, @enum);
+                return AnalyzeEnum(context, stmt, @enum);
             }
             else if (stmt.Query is Statement.Types.Query query)
             {
-                return AnalyzeQuery(stmt, query);
+                return AnalyzeQuery(context, stmt, query);
             }
             else if (stmt.Command is Statement.Types.Command cmd)
             {
-                return AnalyzeCommand(stmt, cmd);
+                return AnalyzeCommand(context, stmt, cmd);
             }
             else
             {

--- a/src/LeanCode.ContractsGenerator/Analyzers/BaseAnalyzer.cs
+++ b/src/LeanCode.ContractsGenerator/Analyzers/BaseAnalyzer.cs
@@ -1,201 +1,200 @@
-namespace LeanCode.ContractsGenerator.Analyzers
+namespace LeanCode.ContractsGenerator.Analyzers;
+
+public class BaseAnalyzer : IAnalyzer
 {
-    public class BaseAnalyzer : IAnalyzer
+    public virtual IEnumerable<AnalyzeError> Analyze(Export export)
     {
-        public virtual IEnumerable<AnalyzeError> Analyze(Export export)
-        {
-            return export.Statements
-                .SelectMany(AnalyzeStatement)
-                .ToList();
-        }
+        return export.Statements
+            .SelectMany(AnalyzeStatement)
+            .ToList();
+    }
 
-        public virtual IEnumerable<AnalyzeError> AnalyzeKnownType(KnownType knownType)
+    public virtual IEnumerable<AnalyzeError> AnalyzeKnownType(KnownType knownType)
+    {
+        return Enumerable.Empty<AnalyzeError>();
+    }
+
+    public virtual IEnumerable<AnalyzeError> AnalyzeValueRef(ValueRef knownType)
+    {
+        return Enumerable.Empty<AnalyzeError>();
+    }
+
+    public virtual IEnumerable<AnalyzeError> AnalyzeGenericTypeRef(TypeRef typeRef, TypeRef.Types.Generic g)
+    {
+        return Enumerable.Empty<AnalyzeError>();
+    }
+
+    public virtual IEnumerable<AnalyzeError> AnalyzeInternalTypeRef(TypeRef typeRef, TypeRef.Types.Internal i)
+    {
+        return i.Arguments.SelectMany(AnalyzeTypeRef);
+    }
+
+    public virtual IEnumerable<AnalyzeError> AnalyzeKnownTypeRef(TypeRef typeRef, TypeRef.Types.Known k)
+    {
+        return k.Arguments
+            .SelectMany(AnalyzeTypeRef)
+            .Concat(AnalyzeKnownType(k.Type));
+    }
+
+    public virtual IEnumerable<AnalyzeError> AnalyzeTypeRef(TypeRef typeRef)
+    {
+        if (typeRef.Internal is TypeRef.Types.Internal i)
+        {
+            return AnalyzeInternalTypeRef(typeRef, i);
+        }
+        else if (typeRef.Known is TypeRef.Types.Known k)
+        {
+            return AnalyzeKnownTypeRef(typeRef, k);
+        }
+        else if (typeRef.Generic is TypeRef.Types.Generic g)
+        {
+            return AnalyzeGenericTypeRef(typeRef, g);
+        }
+        else
         {
             return Enumerable.Empty<AnalyzeError>();
         }
+    }
 
-        public virtual IEnumerable<AnalyzeError> AnalyzeValueRef(ValueRef knownType)
+    public virtual IEnumerable<AnalyzeError> AnalyzeGenericParameter(GenericParameter genericParam)
+    {
+        return Enumerable.Empty<AnalyzeError>();
+    }
+
+    public virtual IEnumerable<AnalyzeError> AnalyzePositionalAttributeArgument(AttributeArgument arg, AttributeArgument.Types.Positional p)
+    {
+        return AnalyzeValueRef(p.Value);
+    }
+
+    public virtual IEnumerable<AnalyzeError> AnalyzeNamedAttributeArgument(AttributeArgument arg, AttributeArgument.Types.Named n)
+    {
+        return AnalyzeValueRef(n.Value);
+    }
+
+    public virtual IEnumerable<AnalyzeError> AnalyzeAttributeArgument(AttributeArgument arg)
+    {
+        if (arg.Positional is AttributeArgument.Types.Positional p)
+        {
+            return AnalyzePositionalAttributeArgument(arg, p);
+        }
+        else if (arg.Named is AttributeArgument.Types.Named n)
+        {
+            return AnalyzeNamedAttributeArgument(arg, n);
+        }
+        else
         {
             return Enumerable.Empty<AnalyzeError>();
         }
+    }
 
-        public virtual IEnumerable<AnalyzeError> AnalyzeGenericTypeRef(TypeRef typeRef, TypeRef.Types.Generic g)
+    public virtual IEnumerable<AnalyzeError> AnalyzeAttributeRef(AttributeRef attrRef)
+    {
+        return attrRef.Argument.SelectMany(AnalyzeAttributeArgument);
+    }
+
+    public virtual IEnumerable<AnalyzeError> AnalyzePropertyRef(PropertyRef propRef)
+    {
+        return AnalyzeTypeRef(propRef.Type)
+            .Concat(propRef.Attributes.SelectMany(AnalyzeAttributeRef));
+    }
+
+    public virtual IEnumerable<AnalyzeError> AnalyzeConstantRef(ConstantRef constant)
+    {
+        return AnalyzeValueRef(constant.Value);
+    }
+
+    public virtual IEnumerable<AnalyzeError> AnalyzeEnumValue(EnumValue enumVal)
+    {
+        return Enumerable.Empty<AnalyzeError>();
+    }
+
+    public virtual IEnumerable<AnalyzeError> AnalyzeGroupErrorCode(ErrorCode errCode, ErrorCode.Types.Group g)
+    {
+        return AnalyzeErrorCodes(g.InnerCodes);
+    }
+
+    public virtual IEnumerable<AnalyzeError> AnalyzeSingleErrorCode(ErrorCode errCode, ErrorCode.Types.Single s)
+    {
+        return Enumerable.Empty<AnalyzeError>();
+    }
+
+    public virtual IEnumerable<AnalyzeError> AnalyzeErrorCode(ErrorCode errCode)
+    {
+        if (errCode.Group is ErrorCode.Types.Group g)
+        {
+            return AnalyzeGroupErrorCode(errCode, g);
+        }
+        else if (errCode.Single is ErrorCode.Types.Single s)
+        {
+            return AnalyzeSingleErrorCode(errCode, s);
+        }
+        else
         {
             return Enumerable.Empty<AnalyzeError>();
         }
+    }
 
-        public virtual IEnumerable<AnalyzeError> AnalyzeInternalTypeRef(TypeRef typeRef, TypeRef.Types.Internal i)
-        {
-            return i.Arguments.SelectMany(AnalyzeTypeRef);
-        }
+    public virtual IEnumerable<AnalyzeError> AnalyzeErrorCodes(IEnumerable<ErrorCode> errCodes)
+    {
+        return errCodes.SelectMany(AnalyzeErrorCode);
+    }
 
-        public virtual IEnumerable<AnalyzeError> AnalyzeKnownTypeRef(TypeRef typeRef, TypeRef.Types.Known k)
-        {
-            return k.Arguments
-                .SelectMany(AnalyzeTypeRef)
-                .Concat(AnalyzeKnownType(k.Type));
-        }
+    public virtual IEnumerable<AnalyzeError> AnalyzeTypeDescriptor(TypeDescriptor descr)
+    {
+        return descr.Extends.SelectMany(AnalyzeTypeRef)
+            .Concat(descr.GenericParameters.SelectMany(AnalyzeGenericParameter))
+            .Concat(descr.Properties.SelectMany(AnalyzePropertyRef))
+            .Concat(descr.Constants.SelectMany(AnalyzeConstantRef));
+    }
 
-        public virtual IEnumerable<AnalyzeError> AnalyzeTypeRef(TypeRef typeRef)
+    public virtual IEnumerable<AnalyzeError> AnalyzeDTO(Statement stmt, Statement.Types.DTO dto)
+    {
+        return AnalyzeTypeDescriptor(dto.TypeDescriptor);
+    }
+
+    public virtual IEnumerable<AnalyzeError> AnalyzeEnum(Statement stmt, Statement.Types.Enum @enum)
+    {
+        return @enum.Members.SelectMany(AnalyzeEnumValue);
+    }
+
+    public virtual IEnumerable<AnalyzeError> AnalyzeQuery(Statement stmt, Statement.Types.Query query)
+    {
+        return AnalyzeTypeDescriptor(query.TypeDescriptor)
+            .Concat(AnalyzeTypeRef(query.ReturnType));
+    }
+
+    public virtual IEnumerable<AnalyzeError> AnalyzeCommand(Statement stmt, Statement.Types.Command command)
+    {
+        return AnalyzeTypeDescriptor(command.TypeDescriptor)
+            .Concat(AnalyzeErrorCodes(command.ErrorCodes));
+    }
+
+    public virtual IEnumerable<AnalyzeError> AnalyzeStatement(Statement stmt)
+    {
+        return AnalyzeInner(stmt)
+            .Concat(stmt.Attributes.SelectMany(AnalyzeAttributeRef));
+
+        IEnumerable<AnalyzeError> AnalyzeInner(Statement stmt)
         {
-            if (typeRef.Internal is TypeRef.Types.Internal i)
+            if (stmt.Dto is Statement.Types.DTO dto)
             {
-                return AnalyzeInternalTypeRef(typeRef, i);
+                return AnalyzeDTO(stmt, dto);
             }
-            else if (typeRef.Known is TypeRef.Types.Known k)
+            else if (stmt.Enum is Statement.Types.Enum @enum)
             {
-                return AnalyzeKnownTypeRef(typeRef, k);
+                return AnalyzeEnum(stmt, @enum);
             }
-            else if (typeRef.Generic is TypeRef.Types.Generic g)
+            else if (stmt.Query is Statement.Types.Query query)
             {
-                return AnalyzeGenericTypeRef(typeRef, g);
+                return AnalyzeQuery(stmt, query);
+            }
+            else if (stmt.Command is Statement.Types.Command cmd)
+            {
+                return AnalyzeCommand(stmt, cmd);
             }
             else
             {
                 return Enumerable.Empty<AnalyzeError>();
-            }
-        }
-
-        public virtual IEnumerable<AnalyzeError> AnalyzeGenericParameter(GenericParameter genericParam)
-        {
-            return Enumerable.Empty<AnalyzeError>();
-        }
-
-        public virtual IEnumerable<AnalyzeError> AnalyzePositionalAttributeArgument(AttributeArgument arg, AttributeArgument.Types.Positional p)
-        {
-            return AnalyzeValueRef(p.Value);
-        }
-
-        public virtual IEnumerable<AnalyzeError> AnalyzeNamedAttributeArgument(AttributeArgument arg, AttributeArgument.Types.Named n)
-        {
-            return AnalyzeValueRef(n.Value);
-        }
-
-        public virtual IEnumerable<AnalyzeError> AnalyzeAttributeArgument(AttributeArgument arg)
-        {
-            if (arg.Positional is AttributeArgument.Types.Positional p)
-            {
-                return AnalyzePositionalAttributeArgument(arg, p);
-            }
-            else if (arg.Named is AttributeArgument.Types.Named n)
-            {
-                return AnalyzeNamedAttributeArgument(arg, n);
-            }
-            else
-            {
-                return Enumerable.Empty<AnalyzeError>();
-            }
-        }
-
-        public virtual IEnumerable<AnalyzeError> AnalyzeAttributeRef(AttributeRef attrRef)
-        {
-            return attrRef.Argument.SelectMany(AnalyzeAttributeArgument);
-        }
-
-        public virtual IEnumerable<AnalyzeError> AnalyzePropertyRef(PropertyRef propRef)
-        {
-            return AnalyzeTypeRef(propRef.Type)
-                .Concat(propRef.Attributes.SelectMany(AnalyzeAttributeRef));
-        }
-
-        public virtual IEnumerable<AnalyzeError> AnalyzeConstantRef(ConstantRef constant)
-        {
-            return AnalyzeValueRef(constant.Value);
-        }
-
-        public virtual IEnumerable<AnalyzeError> AnalyzeEnumValue(EnumValue enumVal)
-        {
-            return Enumerable.Empty<AnalyzeError>();
-        }
-
-        public virtual IEnumerable<AnalyzeError> AnalyzeGroupErrorCode(ErrorCode errCode, ErrorCode.Types.Group g)
-        {
-            return AnalyzeErrorCodes(g.InnerCodes);
-        }
-
-        public virtual IEnumerable<AnalyzeError> AnalyzeSingleErrorCode(ErrorCode errCode, ErrorCode.Types.Single s)
-        {
-            return Enumerable.Empty<AnalyzeError>();
-        }
-
-        public virtual IEnumerable<AnalyzeError> AnalyzeErrorCode(ErrorCode errCode)
-        {
-            if (errCode.Group is ErrorCode.Types.Group g)
-            {
-                return AnalyzeGroupErrorCode(errCode, g);
-            }
-            else if (errCode.Single is ErrorCode.Types.Single s)
-            {
-                return AnalyzeSingleErrorCode(errCode, s);
-            }
-            else
-            {
-                return Enumerable.Empty<AnalyzeError>();
-            }
-        }
-
-        public virtual IEnumerable<AnalyzeError> AnalyzeErrorCodes(IEnumerable<ErrorCode> errCodes)
-        {
-            return errCodes.SelectMany(AnalyzeErrorCode);
-        }
-
-        public virtual IEnumerable<AnalyzeError> AnalyzeTypeDescriptor(TypeDescriptor descr)
-        {
-            return descr.Extends.SelectMany(AnalyzeTypeRef)
-                .Concat(descr.GenericParameters.SelectMany(AnalyzeGenericParameter))
-                .Concat(descr.Properties.SelectMany(AnalyzePropertyRef))
-                .Concat(descr.Constants.SelectMany(AnalyzeConstantRef));
-        }
-
-        public virtual IEnumerable<AnalyzeError> AnalyzeDTO(Statement stmt, Statement.Types.DTO dto)
-        {
-            return AnalyzeTypeDescriptor(dto.TypeDescriptor);
-        }
-
-        public virtual IEnumerable<AnalyzeError> AnalyzeEnum(Statement stmt, Statement.Types.Enum @enum)
-        {
-            return @enum.Members.SelectMany(AnalyzeEnumValue);
-        }
-
-        public virtual IEnumerable<AnalyzeError> AnalyzeQuery(Statement stmt, Statement.Types.Query query)
-        {
-            return AnalyzeTypeDescriptor(query.TypeDescriptor)
-                .Concat(AnalyzeTypeRef(query.ReturnType));
-        }
-
-        public virtual IEnumerable<AnalyzeError> AnalyzeCommand(Statement stmt, Statement.Types.Command command)
-        {
-            return AnalyzeTypeDescriptor(command.TypeDescriptor)
-                .Concat(AnalyzeErrorCodes(command.ErrorCodes));
-        }
-
-        public virtual IEnumerable<AnalyzeError> AnalyzeStatement(Statement stmt)
-        {
-            return AnalyzeInner(stmt)
-                .Concat(stmt.Attributes.SelectMany(AnalyzeAttributeRef));
-
-            IEnumerable<AnalyzeError> AnalyzeInner(Statement stmt)
-            {
-                if (stmt.Dto is Statement.Types.DTO dto)
-                {
-                    return AnalyzeDTO(stmt, dto);
-                }
-                else if (stmt.Enum is Statement.Types.Enum @enum)
-                {
-                    return AnalyzeEnum(stmt, @enum);
-                }
-                else if (stmt.Query is Statement.Types.Query query)
-                {
-                    return AnalyzeQuery(stmt, query);
-                }
-                else if (stmt.Command is Statement.Types.Command cmd)
-                {
-                    return AnalyzeCommand(stmt, cmd);
-                }
-                else
-                {
-                    return Enumerable.Empty<AnalyzeError>();
-                }
             }
         }
     }

--- a/src/LeanCode.ContractsGenerator/Analyzers/BaseAnalyzer.cs
+++ b/src/LeanCode.ContractsGenerator/Analyzers/BaseAnalyzer.cs
@@ -1,0 +1,202 @@
+namespace LeanCode.ContractsGenerator.Analyzers
+{
+    public class BaseAnalyzer : IAnalyzer
+    {
+        public virtual IEnumerable<AnalyzeError> Analyze(Export export)
+        {
+            return export.Statements
+                .SelectMany(AnalyzeStatement)
+                .ToList();
+        }
+
+        public virtual IEnumerable<AnalyzeError> AnalyzeKnownType(KnownType knownType)
+        {
+            return Enumerable.Empty<AnalyzeError>();
+        }
+
+        public virtual IEnumerable<AnalyzeError> AnalyzeValueRef(ValueRef knownType)
+        {
+            return Enumerable.Empty<AnalyzeError>();
+        }
+
+        public virtual IEnumerable<AnalyzeError> AnalyzeGenericTypeRef(TypeRef typeRef, TypeRef.Types.Generic g)
+        {
+            return Enumerable.Empty<AnalyzeError>();
+        }
+
+        public virtual IEnumerable<AnalyzeError> AnalyzeInternalTypeRef(TypeRef typeRef, TypeRef.Types.Internal i)
+        {
+            return i.Arguments.SelectMany(AnalyzeTypeRef);
+        }
+
+        public virtual IEnumerable<AnalyzeError> AnalyzeKnownTypeRef(TypeRef typeRef, TypeRef.Types.Known k)
+        {
+            return k.Arguments
+                .SelectMany(AnalyzeTypeRef)
+                .Concat(AnalyzeKnownType(k.Type));
+        }
+
+        public virtual IEnumerable<AnalyzeError> AnalyzeTypeRef(TypeRef typeRef)
+        {
+            if (typeRef.Internal is TypeRef.Types.Internal i)
+            {
+                return AnalyzeInternalTypeRef(typeRef, i);
+            }
+            else if (typeRef.Known is TypeRef.Types.Known k)
+            {
+                return AnalyzeKnownTypeRef(typeRef, k);
+            }
+            else if (typeRef.Generic is TypeRef.Types.Generic g)
+            {
+                return AnalyzeGenericTypeRef(typeRef, g);
+            }
+            else
+            {
+                return Enumerable.Empty<AnalyzeError>();
+            }
+        }
+
+        public virtual IEnumerable<AnalyzeError> AnalyzeGenericParameter(GenericParameter genericParam)
+        {
+            return Enumerable.Empty<AnalyzeError>();
+        }
+
+        public virtual IEnumerable<AnalyzeError> AnalyzePositionalAttributeArgument(AttributeArgument arg, AttributeArgument.Types.Positional p)
+        {
+            return AnalyzeValueRef(p.Value);
+        }
+
+        public virtual IEnumerable<AnalyzeError> AnalyzeNamedAttributeArgument(AttributeArgument arg, AttributeArgument.Types.Named n)
+        {
+            return AnalyzeValueRef(n.Value);
+        }
+
+        public virtual IEnumerable<AnalyzeError> AnalyzeAttributeArgument(AttributeArgument arg)
+        {
+            if (arg.Positional is AttributeArgument.Types.Positional p)
+            {
+                return AnalyzePositionalAttributeArgument(arg, p);
+            }
+            else if (arg.Named is AttributeArgument.Types.Named n)
+            {
+                return AnalyzeNamedAttributeArgument(arg, n);
+            }
+            else
+            {
+                return Enumerable.Empty<AnalyzeError>();
+            }
+        }
+
+        public virtual IEnumerable<AnalyzeError> AnalyzeAttributeRef(AttributeRef attrRef)
+        {
+            return attrRef.Argument.SelectMany(AnalyzeAttributeArgument);
+        }
+
+        public virtual IEnumerable<AnalyzeError> AnalyzePropertyRef(PropertyRef propRef)
+        {
+            return AnalyzeTypeRef(propRef.Type)
+                .Concat(propRef.Attributes.SelectMany(AnalyzeAttributeRef));
+        }
+
+        public virtual IEnumerable<AnalyzeError> AnalyzeConstantRef(ConstantRef constant)
+        {
+            return AnalyzeValueRef(constant.Value);
+        }
+
+        public virtual IEnumerable<AnalyzeError> AnalyzeEnumValue(EnumValue enumVal)
+        {
+            return Enumerable.Empty<AnalyzeError>();
+        }
+
+        public virtual IEnumerable<AnalyzeError> AnalyzeGroupErrorCode(ErrorCode errCode, ErrorCode.Types.Group g)
+        {
+            return AnalyzeErrorCodes(g.InnerCodes);
+        }
+
+        public virtual IEnumerable<AnalyzeError> AnalyzeSingleErrorCode(ErrorCode errCode, ErrorCode.Types.Single s)
+        {
+            return Enumerable.Empty<AnalyzeError>();
+        }
+
+        public virtual IEnumerable<AnalyzeError> AnalyzeErrorCode(ErrorCode errCode)
+        {
+            if (errCode.Group is ErrorCode.Types.Group g)
+            {
+                return AnalyzeGroupErrorCode(errCode, g);
+            }
+            else if (errCode.Single is ErrorCode.Types.Single s)
+            {
+                return AnalyzeSingleErrorCode(errCode, s);
+            }
+            else
+            {
+                return Enumerable.Empty<AnalyzeError>();
+            }
+        }
+
+        public virtual IEnumerable<AnalyzeError> AnalyzeErrorCodes(IEnumerable<ErrorCode> errCodes)
+        {
+            return errCodes.SelectMany(AnalyzeErrorCode);
+        }
+
+        public virtual IEnumerable<AnalyzeError> AnalyzeTypeDescriptor(TypeDescriptor descr)
+        {
+            return descr.Extends.SelectMany(AnalyzeTypeRef)
+                .Concat(descr.GenericParameters.SelectMany(AnalyzeGenericParameter))
+                .Concat(descr.Properties.SelectMany(AnalyzePropertyRef))
+                .Concat(descr.Constants.SelectMany(AnalyzeConstantRef));
+        }
+
+        public virtual IEnumerable<AnalyzeError> AnalyzeDTO(Statement stmt, Statement.Types.DTO dto)
+        {
+            return AnalyzeTypeDescriptor(dto.TypeDescriptor);
+        }
+
+        public virtual IEnumerable<AnalyzeError> AnalyzeEnum(Statement stmt, Statement.Types.Enum @enum)
+        {
+            return @enum.Members.SelectMany(AnalyzeEnumValue);
+        }
+
+        public virtual IEnumerable<AnalyzeError> AnalyzeQuery(Statement stmt, Statement.Types.Query query)
+        {
+            return AnalyzeTypeDescriptor(query.TypeDescriptor)
+                .Concat(AnalyzeTypeRef(query.ReturnType));
+        }
+
+        public virtual IEnumerable<AnalyzeError> AnalyzeCommand(Statement stmt, Statement.Types.Command command)
+        {
+            return AnalyzeTypeDescriptor(command.TypeDescriptor)
+                .Concat(AnalyzeErrorCodes(command.ErrorCodes));
+        }
+
+        public virtual IEnumerable<AnalyzeError> AnalyzeStatement(Statement stmt)
+        {
+            return AnalyzeInner(stmt)
+                .Concat(stmt.Attributes.SelectMany(AnalyzeAttributeRef));
+
+            IEnumerable<AnalyzeError> AnalyzeInner(Statement stmt)
+            {
+                if (stmt.Dto is Statement.Types.DTO dto)
+                {
+                    return AnalyzeDTO(stmt, dto);
+                }
+                else if (stmt.Enum is Statement.Types.Enum @enum)
+                {
+                    return AnalyzeEnum(stmt, @enum);
+                }
+                else if (stmt.Query is Statement.Types.Query query)
+                {
+                    return AnalyzeQuery(stmt, query);
+                }
+                else if (stmt.Command is Statement.Types.Command cmd)
+                {
+                    return AnalyzeCommand(stmt, cmd);
+                }
+                else
+                {
+                    return Enumerable.Empty<AnalyzeError>();
+                }
+            }
+        }
+    }
+}

--- a/src/LeanCode.ContractsGenerator/Analyzers/ErrorCodesUniqueness.cs
+++ b/src/LeanCode.ContractsGenerator/Analyzers/ErrorCodesUniqueness.cs
@@ -4,13 +4,13 @@ public class ErrorCodesUniqueness : BaseAnalyzer
 {
     public const string Code = "CNTR0003";
 
-    public override IEnumerable<AnalyzeError> AnalyzeErrorCodes(IEnumerable<ErrorCode> errorCodes)
+    public override IEnumerable<AnalyzeError> AnalyzeErrorCodes(AnalyzerContext context, IEnumerable<ErrorCode> errorCodes)
     {
         return errorCodes
             .SelectMany(Flatten)
             .GroupBy(e => e.Code)
             .Where(g => g.Count() > 1)
-            .Select(g => new AnalyzeError(Code, $"Duplicate error codes: {string.Join(", ", g.Select(c => c.Name))}", nameof(ErrorCode), ""));
+            .Select(g => new AnalyzeError(Code, $"Duplicate error codes: {string.Join(", ", g.Select(c => c.Name))}", context));
 
         static IEnumerable<ErrorCode.Types.Single> Flatten(ErrorCode errCode)
         {
@@ -27,22 +27,23 @@ public class ErrorCodesUniqueness : BaseAnalyzer
 
     public override IEnumerable<AnalyzeError> Analyze(Export export)
     {
+        var context = AnalyzerContext.Empty;
+
         return export.Statements
-            .SelectMany(AnalyzeStatement)
+            .SelectMany(s => AnalyzeStatement(context.Descend(s), s))
             .ToList();
     }
 
-    public override IEnumerable<AnalyzeError> AnalyzeCommand(Statement stmt, Statement.Types.Command command)
+    public override IEnumerable<AnalyzeError> AnalyzeCommand(AnalyzerContext context, Statement stmt, Statement.Types.Command command)
     {
-        return AnalyzeErrorCodes(command.ErrorCodes)
-            .Select(e => e with { Name = stmt.Name });
+        return AnalyzeErrorCodes(context.Marked(PathMarker.ErrorCodes), command.ErrorCodes);
     }
 
-    public override IEnumerable<AnalyzeError> AnalyzeStatement(Statement stmt)
+    public override IEnumerable<AnalyzeError> AnalyzeStatement(AnalyzerContext context, Statement stmt)
     {
         if (stmt.Command is Statement.Types.Command cmd)
         {
-            return AnalyzeCommand(stmt, cmd);
+            return AnalyzeCommand(context, stmt, cmd);
         }
         else
         {

--- a/src/LeanCode.ContractsGenerator/Analyzers/ErrorCodesUniqueness.cs
+++ b/src/LeanCode.ContractsGenerator/Analyzers/ErrorCodesUniqueness.cs
@@ -36,7 +36,7 @@ public class ErrorCodesUniqueness : BaseAnalyzer
 
     public override IEnumerable<AnalyzeError> AnalyzeCommand(AnalyzerContext context, Statement stmt, Statement.Types.Command command)
     {
-        return AnalyzeErrorCodes(context.Marked(PathMarker.ErrorCodes), command.ErrorCodes);
+        return AnalyzeErrorCodes(context.ErrorCodes(), command.ErrorCodes);
     }
 
     public override IEnumerable<AnalyzeError> AnalyzeStatement(AnalyzerContext context, Statement stmt)

--- a/src/LeanCode.ContractsGenerator/Analyzers/ErrorCodesUniqueness.cs
+++ b/src/LeanCode.ContractsGenerator/Analyzers/ErrorCodesUniqueness.cs
@@ -1,0 +1,54 @@
+namespace LeanCode.ContractsGenerator.Analyzers
+{
+    public class ErrorCodesUniqueness : BaseAnalyzer
+    {
+        public const string Code = "LNCD003";
+
+        public override IEnumerable<AnalyzeError> AnalyzeErrorCodes(IEnumerable<ErrorCode> errorCodes)
+        {
+            return errorCodes
+                .SelectMany(Flatten)
+                .GroupBy(e => e.Code)
+                .Where(g => g.Count() > 1)
+                .Select(g => new AnalyzeError(Code, $"Duplicate error codes: {string.Join(", ", g.Select(c => c.Name))}", nameof(ErrorCode), ""));
+
+            static IEnumerable<ErrorCode.Types.Single> Flatten(ErrorCode errCode)
+            {
+                if (errCode.Single is ErrorCode.Types.Single s)
+                {
+                    return new[] { s };
+                }
+                else
+                {
+                    return errCode.Group.InnerCodes.SelectMany(Flatten);
+                }
+            }
+        }
+
+        public override IEnumerable<AnalyzeError> Analyze(Export export)
+        {
+            return export.Statements
+                .SelectMany(AnalyzeStatement)
+                .ToList();
+        }
+
+        public override IEnumerable<AnalyzeError> AnalyzeCommand(Statement stmt, Statement.Types.Command command)
+        {
+            return command.ErrorCodes
+                .SelectMany(AnalyzeErrorCode)
+                .Select(e => e with { Name = stmt.Name });
+        }
+
+        public override IEnumerable<AnalyzeError> AnalyzeStatement(Statement stmt)
+        {
+            if (stmt.Command is Statement.Types.Command cmd)
+            {
+                return AnalyzeCommand(stmt, cmd);
+            }
+            else
+            {
+                return Enumerable.Empty<AnalyzeError>();
+            }
+        }
+    }
+}

--- a/src/LeanCode.ContractsGenerator/Analyzers/ErrorCodesUniqueness.cs
+++ b/src/LeanCode.ContractsGenerator/Analyzers/ErrorCodesUniqueness.cs
@@ -2,7 +2,7 @@ namespace LeanCode.ContractsGenerator.Analyzers
 {
     public class ErrorCodesUniqueness : BaseAnalyzer
     {
-        public const string Code = "LNCD003";
+        public const string Code = "CNTR0003";
 
         public override IEnumerable<AnalyzeError> AnalyzeErrorCodes(IEnumerable<ErrorCode> errorCodes)
         {

--- a/src/LeanCode.ContractsGenerator/Analyzers/ErrorCodesUniqueness.cs
+++ b/src/LeanCode.ContractsGenerator/Analyzers/ErrorCodesUniqueness.cs
@@ -1,53 +1,52 @@
-namespace LeanCode.ContractsGenerator.Analyzers
+namespace LeanCode.ContractsGenerator.Analyzers;
+
+public class ErrorCodesUniqueness : BaseAnalyzer
 {
-    public class ErrorCodesUniqueness : BaseAnalyzer
+    public const string Code = "CNTR0003";
+
+    public override IEnumerable<AnalyzeError> AnalyzeErrorCodes(IEnumerable<ErrorCode> errorCodes)
     {
-        public const string Code = "CNTR0003";
+        return errorCodes
+            .SelectMany(Flatten)
+            .GroupBy(e => e.Code)
+            .Where(g => g.Count() > 1)
+            .Select(g => new AnalyzeError(Code, $"Duplicate error codes: {string.Join(", ", g.Select(c => c.Name))}", nameof(ErrorCode), ""));
 
-        public override IEnumerable<AnalyzeError> AnalyzeErrorCodes(IEnumerable<ErrorCode> errorCodes)
+        static IEnumerable<ErrorCode.Types.Single> Flatten(ErrorCode errCode)
         {
-            return errorCodes
-                .SelectMany(Flatten)
-                .GroupBy(e => e.Code)
-                .Where(g => g.Count() > 1)
-                .Select(g => new AnalyzeError(Code, $"Duplicate error codes: {string.Join(", ", g.Select(c => c.Name))}", nameof(ErrorCode), ""));
-
-            static IEnumerable<ErrorCode.Types.Single> Flatten(ErrorCode errCode)
+            if (errCode.Single is ErrorCode.Types.Single s)
             {
-                if (errCode.Single is ErrorCode.Types.Single s)
-                {
-                    return new[] { s };
-                }
-                else
-                {
-                    return errCode.Group.InnerCodes.SelectMany(Flatten);
-                }
-            }
-        }
-
-        public override IEnumerable<AnalyzeError> Analyze(Export export)
-        {
-            return export.Statements
-                .SelectMany(AnalyzeStatement)
-                .ToList();
-        }
-
-        public override IEnumerable<AnalyzeError> AnalyzeCommand(Statement stmt, Statement.Types.Command command)
-        {
-            return AnalyzeErrorCodes(command.ErrorCodes)
-                .Select(e => e with { Name = stmt.Name });
-        }
-
-        public override IEnumerable<AnalyzeError> AnalyzeStatement(Statement stmt)
-        {
-            if (stmt.Command is Statement.Types.Command cmd)
-            {
-                return AnalyzeCommand(stmt, cmd);
+                return new[] { s };
             }
             else
             {
-                return Enumerable.Empty<AnalyzeError>();
+                return errCode.Group.InnerCodes.SelectMany(Flatten);
             }
+        }
+    }
+
+    public override IEnumerable<AnalyzeError> Analyze(Export export)
+    {
+        return export.Statements
+            .SelectMany(AnalyzeStatement)
+            .ToList();
+    }
+
+    public override IEnumerable<AnalyzeError> AnalyzeCommand(Statement stmt, Statement.Types.Command command)
+    {
+        return AnalyzeErrorCodes(command.ErrorCodes)
+            .Select(e => e with { Name = stmt.Name });
+    }
+
+    public override IEnumerable<AnalyzeError> AnalyzeStatement(Statement stmt)
+    {
+        if (stmt.Command is Statement.Types.Command cmd)
+        {
+            return AnalyzeCommand(stmt, cmd);
+        }
+        else
+        {
+            return Enumerable.Empty<AnalyzeError>();
         }
     }
 }

--- a/src/LeanCode.ContractsGenerator/Analyzers/ErrorCodesUniqueness.cs
+++ b/src/LeanCode.ContractsGenerator/Analyzers/ErrorCodesUniqueness.cs
@@ -34,8 +34,7 @@ namespace LeanCode.ContractsGenerator.Analyzers
 
         public override IEnumerable<AnalyzeError> AnalyzeCommand(Statement stmt, Statement.Types.Command command)
         {
-            return command.ErrorCodes
-                .SelectMany(AnalyzeErrorCode)
+            return AnalyzeErrorCodes(command.ErrorCodes)
                 .Select(e => e with { Name = stmt.Name });
         }
 

--- a/src/LeanCode.ContractsGenerator/Analyzers/ExternalTypeCheck.cs
+++ b/src/LeanCode.ContractsGenerator/Analyzers/ExternalTypeCheck.cs
@@ -22,8 +22,7 @@ public class ExternalTypeCheck : BaseAnalyzer
         }
         else
         {
-            return base.AnalyzeInternalTypeRef(context, typeRef, i)
-                .Append(new(Code, $"Internal type `{i.Name}` is not known.", context));
+            return new[] { new AnalyzeError(Code, $"Internal type `{i.Name}` is not known.", context) };
         }
     }
 

--- a/src/LeanCode.ContractsGenerator/Analyzers/ExternalTypeCheck.cs
+++ b/src/LeanCode.ContractsGenerator/Analyzers/ExternalTypeCheck.cs
@@ -1,0 +1,36 @@
+using System.Collections.Immutable;
+
+namespace LeanCode.ContractsGenerator.Analyzers;
+
+public class ExternalTypeCheck : BaseAnalyzer
+{
+    public const string Code = "CNTR0004";
+
+    private ImmutableHashSet<string> knownTypes = ImmutableHashSet<string>.Empty;
+
+    public override IEnumerable<AnalyzeError> Analyze(Export export)
+    {
+        knownTypes = GatherTypes(export);
+        return base.Analyze(export);
+    }
+
+    public override IEnumerable<AnalyzeError> AnalyzeInternalTypeRef(AnalyzerContext context, TypeRef typeRef, TypeRef.Types.Internal i)
+    {
+        if (knownTypes.Contains(i.Name))
+        {
+            return base.AnalyzeInternalTypeRef(context, typeRef, i);
+        }
+        else
+        {
+            return base.AnalyzeInternalTypeRef(context, typeRef, i)
+                .Append(new(Code, $"Internal type `{i.Name}` is not known.", context));
+        }
+    }
+
+    private static ImmutableHashSet<string> GatherTypes(Export export)
+    {
+        return export.Statements
+            .Select(s => s.Name)
+            .ToImmutableHashSet();
+    }
+}

--- a/src/LeanCode.ContractsGenerator/Analyzers/InternalStructureCheck.cs
+++ b/src/LeanCode.ContractsGenerator/Analyzers/InternalStructureCheck.cs
@@ -4,17 +4,17 @@ public class InternalStructureCheck : BaseAnalyzer
 {
     public const string Code = "CNTR0001";
 
-    public override IEnumerable<AnalyzeError> AnalyzeTypeRef(TypeRef typeRef)
+    public override IEnumerable<AnalyzeError> AnalyzeTypeRef(AnalyzerContext context, TypeRef typeRef)
     {
         if (typeRef.Generic is null &&
             typeRef.Internal is null &&
             typeRef.Known is null)
         {
-            yield return new(Code, $"`{nameof(TypeRef)}` type is unknown: {typeRef}.", nameof(TypeRef), "");
+            yield return new(Code, $"`{nameof(TypeRef)}` type is unknown: {typeRef}.", context);
         }
     }
 
-    public override IEnumerable<AnalyzeError> AnalyzeValueRef(ValueRef vr)
+    public override IEnumerable<AnalyzeError> AnalyzeValueRef(AnalyzerContext context, ValueRef vr)
     {
         if (vr.Null is null &&
             vr.Number is null &&
@@ -22,34 +22,34 @@ public class InternalStructureCheck : BaseAnalyzer
             vr.String is null &&
             vr.Bool is null)
         {
-            yield return new(Code, $"`{nameof(ValueRef)}` type is unknown: {vr}.", nameof(ValueRef), "");
+            yield return new(Code, $"`{nameof(ValueRef)}` type is unknown: {vr}.", context);
         }
     }
 
-    public override IEnumerable<AnalyzeError> AnalyzeAttributeArgument(AttributeArgument arg)
+    public override IEnumerable<AnalyzeError> AnalyzeAttributeArgument(AnalyzerContext context, AttributeArgument arg)
     {
         if (arg.Positional is null && arg.Named is null)
         {
-            yield return new(Code, $"`{nameof(AttributeArgument)}` type is unknown: {arg}.", nameof(AttributeArgument), "");
+            yield return new(Code, $"`{nameof(AttributeArgument)}` type is unknown: {arg}.", context);
         }
     }
 
-    public override IEnumerable<AnalyzeError> AnalyzeErrorCode(ErrorCode errCode)
+    public override IEnumerable<AnalyzeError> AnalyzeErrorCode(AnalyzerContext context, ErrorCode errCode)
     {
         if (errCode.Single is null && errCode.Group is null)
         {
-            yield return new(Code, $"`{nameof(ErrorCode)}` type is unknown: {errCode}.", nameof(ErrorCode), "");
+            yield return new(Code, $"`{nameof(ErrorCode)}` type is unknown: {errCode}.", context);
         }
     }
 
-    public override IEnumerable<AnalyzeError> AnalyzeStatement(Statement stmt)
+    public override IEnumerable<AnalyzeError> AnalyzeStatement(AnalyzerContext context, Statement stmt)
     {
         if (stmt.Dto is null &&
             stmt.Enum is null &&
             stmt.Query is null &&
             stmt.Command is null)
         {
-            yield return new(Code, $"`{nameof(Statement)}` type is unknown: {stmt}.", nameof(Statement), stmt.Name);
+            yield return new(Code, $"`{nameof(Statement)}` type is unknown: {stmt}.", context);
         }
     }
 }

--- a/src/LeanCode.ContractsGenerator/Analyzers/InternalStructureCheck.cs
+++ b/src/LeanCode.ContractsGenerator/Analyzers/InternalStructureCheck.cs
@@ -1,56 +1,55 @@
-namespace LeanCode.ContractsGenerator.Analyzers
+namespace LeanCode.ContractsGenerator.Analyzers;
+
+public class InternalStructureCheck : BaseAnalyzer
 {
-    public class InternalStructureCheck : BaseAnalyzer
+    public const string Code = "CNTR0001";
+
+    public override IEnumerable<AnalyzeError> AnalyzeTypeRef(TypeRef typeRef)
     {
-        public const string Code = "CNTR0001";
-
-        public override IEnumerable<AnalyzeError> AnalyzeTypeRef(TypeRef typeRef)
+        if (typeRef.Generic is null &&
+            typeRef.Internal is null &&
+            typeRef.Known is null)
         {
-            if (typeRef.Generic is null &&
-                typeRef.Internal is null &&
-                typeRef.Known is null)
-            {
-                yield return new(Code, $"`{nameof(TypeRef)}` type is unknown: {typeRef}.", nameof(TypeRef), "");
-            }
+            yield return new(Code, $"`{nameof(TypeRef)}` type is unknown: {typeRef}.", nameof(TypeRef), "");
         }
+    }
 
-        public override IEnumerable<AnalyzeError> AnalyzeValueRef(ValueRef vr)
+    public override IEnumerable<AnalyzeError> AnalyzeValueRef(ValueRef vr)
+    {
+        if (vr.Null is null &&
+            vr.Number is null &&
+            vr.FloatingPoint is null &&
+            vr.String is null &&
+            vr.Bool is null)
         {
-            if (vr.Null is null &&
-                vr.Number is null &&
-                vr.FloatingPoint is null &&
-                vr.String is null &&
-                vr.Bool is null)
-            {
-                yield return new(Code, $"`{nameof(ValueRef)}` type is unknown: {vr}.", nameof(ValueRef), "");
-            }
+            yield return new(Code, $"`{nameof(ValueRef)}` type is unknown: {vr}.", nameof(ValueRef), "");
         }
+    }
 
-        public override IEnumerable<AnalyzeError> AnalyzeAttributeArgument(AttributeArgument arg)
+    public override IEnumerable<AnalyzeError> AnalyzeAttributeArgument(AttributeArgument arg)
+    {
+        if (arg.Positional is null && arg.Named is null)
         {
-            if (arg.Positional is null && arg.Named is null)
-            {
-                yield return new(Code, $"`{nameof(AttributeArgument)}` type is unknown: {arg}.", nameof(AttributeArgument), "");
-            }
+            yield return new(Code, $"`{nameof(AttributeArgument)}` type is unknown: {arg}.", nameof(AttributeArgument), "");
         }
+    }
 
-        public override IEnumerable<AnalyzeError> AnalyzeErrorCode(ErrorCode errCode)
+    public override IEnumerable<AnalyzeError> AnalyzeErrorCode(ErrorCode errCode)
+    {
+        if (errCode.Single is null && errCode.Group is null)
         {
-            if (errCode.Single is null && errCode.Group is null)
-            {
-                yield return new(Code, $"`{nameof(ErrorCode)}` type is unknown: {errCode}.", nameof(ErrorCode), "");
-            }
+            yield return new(Code, $"`{nameof(ErrorCode)}` type is unknown: {errCode}.", nameof(ErrorCode), "");
         }
+    }
 
-        public override IEnumerable<AnalyzeError> AnalyzeStatement(Statement stmt)
+    public override IEnumerable<AnalyzeError> AnalyzeStatement(Statement stmt)
+    {
+        if (stmt.Dto is null &&
+            stmt.Enum is null &&
+            stmt.Query is null &&
+            stmt.Command is null)
         {
-            if (stmt.Dto is null &&
-                stmt.Enum is null &&
-                stmt.Query is null &&
-                stmt.Command is null)
-            {
-                yield return new(Code, $"`{nameof(Statement)}` type is unknown: {stmt}.", nameof(Statement), stmt.Name);
-            }
+            yield return new(Code, $"`{nameof(Statement)}` type is unknown: {stmt}.", nameof(Statement), stmt.Name);
         }
     }
 }

--- a/src/LeanCode.ContractsGenerator/Analyzers/InternalStructureCheck.cs
+++ b/src/LeanCode.ContractsGenerator/Analyzers/InternalStructureCheck.cs
@@ -1,0 +1,56 @@
+namespace LeanCode.ContractsGenerator.Analyzers
+{
+    public class InternalStructureCheck : BaseAnalyzer
+    {
+        public const string Code = "LNCD001";
+
+        public override IEnumerable<AnalyzeError> AnalyzeTypeRef(TypeRef typeRef)
+        {
+            if (typeRef.Generic is null &&
+                typeRef.Internal is null &&
+                typeRef.Known is null)
+            {
+                yield return new(Code, $"`{nameof(TypeRef)}` type is unknown: {typeRef}.", nameof(TypeRef), "");
+            }
+        }
+
+        public override IEnumerable<AnalyzeError> AnalyzeValueRef(ValueRef vr)
+        {
+            if (vr.Null is null &&
+                vr.Number is null &&
+                vr.FloatingPoint is null &&
+                vr.String is null &&
+                vr.Bool is null)
+            {
+                yield return new(Code, $"`{nameof(ValueRef)}` type is unknown: {vr}.", nameof(ValueRef), "");
+            }
+        }
+
+        public override IEnumerable<AnalyzeError> AnalyzeAttributeArgument(AttributeArgument arg)
+        {
+            if (arg.Positional is null && arg.Named is null)
+            {
+                yield return new(Code, $"`{nameof(AttributeArgument)}` type is unknown: {arg}.", nameof(AttributeArgument), "");
+            }
+        }
+
+        public override IEnumerable<AnalyzeError> AnalyzeErrorCode(ErrorCode errCode)
+        {
+            if (errCode.Single is null && errCode.Group is null)
+            {
+                yield return new(Code, $"`{nameof(ErrorCode)}` type is unknown: {errCode}.", nameof(ErrorCode), "");
+            }
+        }
+
+        public override IEnumerable<AnalyzeError> AnalyzeStatement(Statement stmt)
+        {
+            if (stmt.Dto is null &&
+                stmt.Enum is null &&
+                stmt.Query is null &&
+                stmt.Command is null)
+            {
+                yield return new(Code, $"`{nameof(Statement)}` type is unknown: {stmt}.", nameof(Statement), stmt.Name);
+            }
+        }
+    }
+}

--- a/src/LeanCode.ContractsGenerator/Analyzers/InternalStructureCheck.cs
+++ b/src/LeanCode.ContractsGenerator/Analyzers/InternalStructureCheck.cs
@@ -2,7 +2,7 @@ namespace LeanCode.ContractsGenerator.Analyzers
 {
     public class InternalStructureCheck : BaseAnalyzer
     {
-        public const string Code = "LNCD001";
+        public const string Code = "CNTR0001";
 
         public override IEnumerable<AnalyzeError> AnalyzeTypeRef(TypeRef typeRef)
         {

--- a/src/LeanCode.ContractsGenerator/Analyzers/KnownTypeCheck.cs
+++ b/src/LeanCode.ContractsGenerator/Analyzers/KnownTypeCheck.cs
@@ -6,11 +6,11 @@ public class KnownTypeCheck : BaseAnalyzer
 
     public const string Code = "CNTR0002";
 
-    public override IEnumerable<AnalyzeError> AnalyzeKnownType(KnownType knownType)
+    public override IEnumerable<AnalyzeError> AnalyzeKnownType(AnalyzerContext context, KnownType knownType)
     {
         if (!ValidKnownTypeValues.Contains(knownType))
         {
-            yield return new(Code, $"`KnownType` value {knownType} is unsupported.", knownType.ToString(), knownType.ToString());
+            yield return new(Code, $"`KnownType` value {knownType} is unsupported.", context);
         }
     }
 }

--- a/src/LeanCode.ContractsGenerator/Analyzers/KnownTypeCheck.cs
+++ b/src/LeanCode.ContractsGenerator/Analyzers/KnownTypeCheck.cs
@@ -4,7 +4,7 @@ namespace LeanCode.ContractsGenerator.Analyzers
     {
         private static readonly IReadOnlySet<KnownType> ValidKnownTypeValues = Enum.GetValues<KnownType>().ToHashSet();
 
-        public const string Code = "LNCD002";
+        public const string Code = "CNTR0002";
 
         public override IEnumerable<AnalyzeError> AnalyzeKnownType(KnownType knownType)
         {

--- a/src/LeanCode.ContractsGenerator/Analyzers/KnownTypeCheck.cs
+++ b/src/LeanCode.ContractsGenerator/Analyzers/KnownTypeCheck.cs
@@ -1,0 +1,17 @@
+namespace LeanCode.ContractsGenerator.Analyzers
+{
+    public class KnownTypeCheck : BaseAnalyzer
+    {
+        private static readonly IReadOnlySet<KnownType> ValidKnownTypeValues = Enum.GetValues<KnownType>().ToHashSet();
+
+        public const string Code = "LNCD002";
+
+        public override IEnumerable<AnalyzeError> AnalyzeKnownType(KnownType knownType)
+        {
+            if (!ValidKnownTypeValues.Contains(knownType))
+            {
+                yield return new(Code, $"`KnownType` value {knownType} is unsupported.", knownType.ToString(), knownType.ToString());
+            }
+        }
+    }
+}

--- a/src/LeanCode.ContractsGenerator/Analyzers/KnownTypeCheck.cs
+++ b/src/LeanCode.ContractsGenerator/Analyzers/KnownTypeCheck.cs
@@ -1,17 +1,16 @@
-namespace LeanCode.ContractsGenerator.Analyzers
+namespace LeanCode.ContractsGenerator.Analyzers;
+
+public class KnownTypeCheck : BaseAnalyzer
 {
-    public class KnownTypeCheck : BaseAnalyzer
+    private static readonly IReadOnlySet<KnownType> ValidKnownTypeValues = Enum.GetValues<KnownType>().ToHashSet();
+
+    public const string Code = "CNTR0002";
+
+    public override IEnumerable<AnalyzeError> AnalyzeKnownType(KnownType knownType)
     {
-        private static readonly IReadOnlySet<KnownType> ValidKnownTypeValues = Enum.GetValues<KnownType>().ToHashSet();
-
-        public const string Code = "CNTR0002";
-
-        public override IEnumerable<AnalyzeError> AnalyzeKnownType(KnownType knownType)
+        if (!ValidKnownTypeValues.Contains(knownType))
         {
-            if (!ValidKnownTypeValues.Contains(knownType))
-            {
-                yield return new(Code, $"`KnownType` value {knownType} is unsupported.", knownType.ToString(), knownType.ToString());
-            }
+            yield return new(Code, $"`KnownType` value {knownType} is unsupported.", knownType.ToString(), knownType.ToString());
         }
     }
 }

--- a/src/LeanCode.ContractsGenerator/Generation/ContractsGenerator.cs
+++ b/src/LeanCode.ContractsGenerator/Generation/ContractsGenerator.cs
@@ -19,6 +19,12 @@ public class ContractsGenerator
 
     public Export Generate()
     {
+        var export = GenerateCore();
+        return Analyze(export);
+    }
+
+    private Export GenerateCore()
+    {
         var export = new Export() { ProjectName = contracts.ProjectName };
         contracts.ListAllTypes()
             .Select(ProcessType)
@@ -30,6 +36,19 @@ public class ContractsGenerator
         ErrorCodes.ListKnownGroups(export.Statements)
             .SaveToRepeatedField(export.KnownErrorGroups);
         return export;
+    }
+
+    private static Export Analyze(Export export)
+    {
+        var errors = new Analyzers.AllAnalyzers().Analyze(export).ToList();
+        if (errors.Count > 0)
+        {
+            throw new AnalyzeFailedException(errors);
+        }
+        else
+        {
+            return export;
+        }
     }
 
     private Statement? ProcessType(INamedTypeSymbol? symbol)

--- a/src/LeanCode.ContractsGenerator/IAnalyzer.cs
+++ b/src/LeanCode.ContractsGenerator/IAnalyzer.cs
@@ -1,0 +1,9 @@
+namespace LeanCode.ContractsGenerator
+{
+    public interface IAnalyzer
+    {
+        IEnumerable<AnalyzeError> Analyze(Export export);
+    }
+
+    public record AnalyzeError(string Code, string Message, string Type, string Name);
+}

--- a/src/LeanCode.ContractsGenerator/IAnalyzer.cs
+++ b/src/LeanCode.ContractsGenerator/IAnalyzer.cs
@@ -1,9 +1,8 @@
-namespace LeanCode.ContractsGenerator
-{
-    public interface IAnalyzer
-    {
-        IEnumerable<AnalyzeError> Analyze(Export export);
-    }
+namespace LeanCode.ContractsGenerator;
 
-    public record AnalyzeError(string Code, string Message, string Type, string Name);
+public interface IAnalyzer
+{
+    IEnumerable<AnalyzeError> Analyze(Export export);
 }
+
+public record AnalyzeError(string Code, string Message, string Type, string Name);

--- a/src/LeanCode.ContractsGenerator/IAnalyzer.cs
+++ b/src/LeanCode.ContractsGenerator/IAnalyzer.cs
@@ -5,4 +5,4 @@ public interface IAnalyzer
     IEnumerable<AnalyzeError> Analyze(Export export);
 }
 
-public record AnalyzeError(string Code, string Message, string Type, string Name);
+public record AnalyzeError(string Code, string Message, AnalyzerContext Context);


### PR DESCRIPTION
~~This is a draft of the analyzers functionality. It lacks some features:~~

1. ~~Correct _context_ tracking (simple name is not enough, we need more),~~
2. ~~Error reporting,~~
3. Better analyzer invocation (the `GenerateCore` + `Analyze` tandem is just an idea),
4. ~~Moar analyzers.~~

I have vague idea on how to address the first two points (but I will gladly take your ideas here!), but the third point is... problematic. I'm not sure if leaving the exception there is OK-ish or if I should rather go with `Either` result. What do you think?

Also, I have a couple of analyzers in mind:
1. Duplicate type detection,
2. Duplicate property detection,
3. Duplicate constant detection,
4. Duplicate enum value detection,
5. Type existence (e.g. `TypeRef.Internal` points to internal type) - this will also report, e.g., `System.Decimal` - done.

But that surely doesn't cover everything and I would really like to gather ideas here.