### PR TITLE
Remove Buildalyzer and use MSBuild more directly

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/bin/Debug/net5.0/LeanCode.ContractsGenerator.dll",
+            "program": "${workspaceFolder}/src/LeanCode.ContractsGenerator/bin/Debug/net6.0/LeanCode.ContractsGenerator.dll",
             "args": [],
             "cwd": "${workspaceFolder}",
             "console": "internalConsole",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,7 @@
             "type": "process",
             "args": [
                 "build",
-                "${workspaceFolder}/LeanCode.ContractsGenerator/LeanCode.ContractsGenerator.csproj",
+                "${workspaceFolder}/src/LeanCode.ContractsGenerator/LeanCode.ContractsGenerator.csproj",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
             ],
@@ -19,7 +19,7 @@
             "type": "process",
             "args": [
                 "publish",
-                "${workspaceFolder}/LeanCode.ContractsGenerator/LeanCode.ContractsGenerator.csproj",
+                "${workspaceFolder}/src/LeanCode.ContractsGenerator/LeanCode.ContractsGenerator.csproj",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
             ],
@@ -32,7 +32,7 @@
             "args": [
                 "watch",
                 "run",
-                "${workspaceFolder}/LeanCode.ContractsGenerator/LeanCode.ContractsGenerator.csproj",
+                "${workspaceFolder}/src/LeanCode.ContractsGenerator/LeanCode.ContractsGenerator.csproj",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
             ],

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
 
   <PropertyGroup>
+    <PreserveCompilationContext>true</PreserveCompilationContext>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,8 @@
 <Project>
+
   <PropertyGroup>
     <CoreLibVersion>6.0.1447</CoreLibVersion>
+    <RoslynVersion>4.0.0-3.final</RoslynVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,16 +11,20 @@
 
     <PackageReference Update="CommandLineParser" Version="2.9.0-preview1" />
 
-    <PackageReference Update="Buildalyzer" Version="3.2.3" />
-    <PackageReference Update="Buildalyzer.Workspaces" Version="3.2.3" />
-
     <PackageReference Update="LeanCode.CQRS" Version="$(CoreLibVersion)" />
     <PackageReference Update="LeanCode.CQRS.Security" Version="$(CoreLibVersion)" />
 
     <PackageReference Update="LeanCode.Time" Version="6.0.1327" />
 
-    <PackageReference Update="Microsoft.CodeAnalysis" Version="3.11.0" />
-    <PackageReference Update="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0-preview.7.21377.19" />
+    <PackageReference Update="Microsoft.Build.Locator" Version="1.4.1" />
+
+    <PackageReference Update="Microsoft.CodeAnalysis" Version="$(RoslynVersion)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynVersion)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynVersion)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(RoslynVersion)" />
+
+    <PackageReference Update="Microsoft.Extensions.DependencyModel" Version="6.0.0-rc.*" />
+    <PackageReference Update="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0-rc.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -18,7 +18,6 @@
 
     <PackageReference Update="Microsoft.Build.Locator" Version="1.4.1" />
 
-    <PackageReference Update="Microsoft.CodeAnalysis" Version="$(RoslynVersion)" />
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynVersion)" />
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynVersion)" />
     <PackageReference Update="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(RoslynVersion)" />

--- a/src/LeanCode.ContractsGenerator.Tests/ExampleBased/Glob.cs
+++ b/src/LeanCode.ContractsGenerator.Tests/ExampleBased/Glob.cs
@@ -1,0 +1,42 @@
+using System;
+using Xunit;
+using static LeanCode.ContractsGenerator.Tests.ExampleBasedHelpers;
+
+namespace LeanCode.ContractsGenerator.Tests.ExampleBased
+{
+    public class Glob
+    {
+        [Fact]
+        public void Globbing_finds_necessary_files()
+        {
+            GlobCompiles(
+                includes: new[] { "project/globs/**/*.cs", },
+                excludes: Array.Empty<string>())
+                .WithCommand("A.Command")
+                .WithQuery("B.Query")
+                .WithDto("A.Dto");
+        }
+
+        [Fact]
+        public void Globbing_includes_correct_files()
+        {
+            GlobCompiles(
+                includes: new[] { "project/globs/A/*", },
+                excludes: Array.Empty<string>())
+                .WithCommand("A.Command")
+                .WithDto("A.Dto")
+                .Without("B.Query");
+        }
+
+        [Fact]
+        public void Globbing_excludes_correct_files()
+        {
+            GlobCompiles(
+                includes: new[] { "project/globs/**", },
+                excludes: new[] { "**/Dto.cs" })
+                .WithCommand("A.Command")
+                .Without("A.Dto")
+                .WithQuery("B.Query");
+        }
+    }
+}

--- a/src/LeanCode.ContractsGenerator.Tests/ExampleBased/Project.cs
+++ b/src/LeanCode.ContractsGenerator.Tests/ExampleBased/Project.cs
@@ -59,38 +59,5 @@ namespace LeanCode.ContractsGenerator.Tests.ExampleBased
                 .WithCommand("A.Command")
                 .WithQuery("B.Query");
         }
-
-        [Fact]
-        public void Globbing_finds_necessary_files()
-        {
-            GlobCompiles(
-                includes: new[] { "project/globs/**/*.cs", },
-                excludes: Array.Empty<string>())
-                .WithCommand("A.Command")
-                .WithQuery("B.Query")
-                .WithDto("A.Dto");
-        }
-
-        [Fact]
-        public void Globbing_includes_correct_files()
-        {
-            GlobCompiles(
-                includes: new[] { "project/globs/A/*", },
-                excludes: Array.Empty<string>())
-                .WithCommand("A.Command")
-                .WithDto("A.Dto")
-                .Without("B.Query");
-        }
-
-        [Fact]
-        public void Globbing_excludes_correct_files()
-        {
-            GlobCompiles(
-                includes: new[] { "project/globs/**", },
-                excludes: new[] { "**/Dto.cs" })
-                .WithCommand("A.Command")
-                .Without("A.Dto")
-                .WithQuery("B.Query");
-        }
     }
 }

--- a/src/LeanCode.ContractsGenerator.Tests/ExampleBased/Project.cs
+++ b/src/LeanCode.ContractsGenerator.Tests/ExampleBased/Project.cs
@@ -4,6 +4,10 @@ using static LeanCode.ContractsGenerator.Tests.ExampleBasedHelpers;
 
 namespace LeanCode.ContractsGenerator.Tests.ExampleBased
 {
+    [CollectionDefinition(nameof(MSBuildTestCurrentDirectoryWorkaroundCollection), DisableParallelization = true)]
+    public class MSBuildTestCurrentDirectoryWorkaroundCollection { }
+
+    [Collection(nameof(MSBuildTestCurrentDirectoryWorkaroundCollection))]
     public class Project
     {
         [Fact]

--- a/src/LeanCode.ContractsGenerator/ContractTypes.cs
+++ b/src/LeanCode.ContractsGenerator/ContractTypes.cs
@@ -1,10 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using LeanCode.CQRS;
 using LeanCode.CQRS.Security;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+
+#pragma warning disable RS1024
 
 namespace LeanCode.ContractsGenerator
 {

--- a/src/LeanCode.ContractsGenerator/LeanCode.ContractsGenerator.csproj
+++ b/src/LeanCode.ContractsGenerator/LeanCode.ContractsGenerator.csproj
@@ -11,8 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Buildalyzer" />
-    <PackageReference Include="Buildalyzer.Workspaces" />
     <PackageReference Include="CommandLineParser" />
     <PackageReference Include="Google.Protobuf" />
     <PackageReference Include="Grpc.Tools">
@@ -23,7 +21,15 @@
     <PackageReference Include="LeanCode.CQRS" />
     <PackageReference Include="LeanCode.CQRS.Security" />
     <PackageReference Include="LeanCode.Time" />
+
+    <PackageReference Include="Microsoft.Build.Locator" />
+
     <PackageReference Include="Microsoft.CodeAnalysis" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />
+
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
   </ItemGroup>
 

--- a/src/LeanCode.ContractsGenerator/LeanCode.ContractsGenerator.csproj
+++ b/src/LeanCode.ContractsGenerator/LeanCode.ContractsGenerator.csproj
@@ -24,7 +24,6 @@
 
     <PackageReference Include="Microsoft.Build.Locator" />
 
-    <PackageReference Include="Microsoft.CodeAnalysis" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />

--- a/src/LeanCode.ContractsGenerator/LooseAssemblyVersionLoader.cs
+++ b/src/LeanCode.ContractsGenerator/LooseAssemblyVersionLoader.cs
@@ -1,0 +1,83 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
+
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace LeanCode.ContractsGenerator;
+
+internal static class LooseVersionAssemblyLoader
+{
+    private static readonly Dictionary<string, Assembly> PathsToAssemblies = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly Dictionary<string, Assembly> NamesToAssemblies = new();
+
+    private static readonly object Guard = new();
+    private static readonly string[] Extensions = new[] { "ni.dll", "ni.exe", "dll", "exe" };
+
+    /// <summary>
+    /// Register an assembly loader that will load assemblies with higher version than what was requested.
+    /// </summary>
+    public static void Register(string searchPath)
+    {
+        AssemblyLoadContext.Default.Resolving += (AssemblyLoadContext context, AssemblyName assemblyName) =>
+        {
+            lock (Guard)
+            {
+                if (NamesToAssemblies.TryGetValue(assemblyName.FullName, out var assembly))
+                {
+                    return assembly;
+                }
+
+                return TryResolveAssemblyFromPaths_NoLock(context, assemblyName, searchPath);
+            }
+        };
+    }
+
+    private static Assembly TryResolveAssemblyFromPaths_NoLock(AssemblyLoadContext context, AssemblyName assemblyName, string searchPath)
+    {
+        foreach (var cultureSubfolder in string.IsNullOrEmpty(assemblyName.CultureName)
+            // If no culture is specified, attempt to load directly from
+            // the known dependency paths.
+            ? new[] { string.Empty }
+            // Search for satellite assemblies in culture subdirectories
+            // of the assembly search directories, but fall back to the
+            // bare search directory if that fails.
+            : new[] { assemblyName.CultureName, string.Empty })
+        {
+            foreach (var extension in Extensions)
+            {
+                var candidatePath = Path.Combine(
+                    searchPath, cultureSubfolder, $"{assemblyName.Name}.{extension}");
+
+                var isAssemblyLoaded = PathsToAssemblies.ContainsKey(candidatePath);
+                if (isAssemblyLoaded || !File.Exists(candidatePath))
+                {
+                    continue;
+                }
+
+                var candidateAssemblyName = AssemblyLoadContext.GetAssemblyName(candidatePath);
+                if (candidateAssemblyName.Version < assemblyName.Version)
+                {
+                    continue;
+                }
+
+                return LoadAndCache_NoLock(context, candidatePath);
+            }
+        }
+
+        return null;
+    }
+
+    private static Assembly LoadAndCache_NoLock(AssemblyLoadContext context, string fullPath)
+    {
+        var assembly = context.LoadFromAssemblyPath(fullPath);
+        var name = assembly.FullName;
+
+        PathsToAssemblies[fullPath] = assembly;
+        NamesToAssemblies[name] = assembly;
+
+        return assembly;
+    }
+}

--- a/src/LeanCode.ContractsGenerator/MSBuildHelper.cs
+++ b/src/LeanCode.ContractsGenerator/MSBuildHelper.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
+
+using Microsoft.Build.Locator;
+using Microsoft.CodeAnalysis.MSBuild;
+
+namespace LeanCode.ContractsGenerator;
+
+public static class MSBuildHelper
+{
+    static MSBuildHelper()
+    {
+        // QueryVisualStudioInstances returns Visual Studio installations on .NET Framework, and .NET Core SDK
+        // installations on .NET Core. We use the one with the most recent version.
+        var msBuildInstance = MSBuildLocator.QueryVisualStudioInstances().OrderByDescending(x => x.Version).First();
+
+        // Since we do not inherit msbuild.deps.json when referencing the SDK copy
+        // of MSBuild and because the SDK no longer ships with version matched assemblies, we
+        // register an assembly loader that will load assemblies from the msbuild path with
+        // equal or higher version numbers than requested.
+        LooseVersionAssemblyLoader.Register(msBuildInstance.MSBuildPath);
+
+        MSBuildLocator.RegisterInstance(msBuildInstance);
+    }
+
+    public static MSBuildWorkspace CreateWorkspace()
+    {
+        return MSBuildWorkspace
+            .Create(new Dictionary<string, string>
+            {
+                // This property ensures that XAML files will be compiled in the current AppDomain
+                // rather than a separate one. Any tasks isolated in AppDomains or tasks that create
+                // AppDomains will likely not work due to https://github.com/Microsoft/MSBuildLocator/issues/16.
+                ["AlwaysCompileMarkupFilesInSeparateDomain"] = bool.FalseString,
+
+                // Use the preview language version to force the full set of available analyzers to run on the project.
+                ["LangVersion"] = "preview",
+
+                ["TargetFrameworks"] = "net6.0",
+                ["TargetFramework"] = "net6.0",
+            });
+    }
+}

--- a/src/LeanCode.ContractsGenerator/ObjectExtensions.cs
+++ b/src/LeanCode.ContractsGenerator/ObjectExtensions.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace LeanCode.ContractsGenerator
 {
     public static class ObjectExtensions
@@ -21,7 +19,7 @@ namespace LeanCode.ContractsGenerator
                 double v => new ValueRef { FloatingPoint = new() { Value = v } },
                 string v => new ValueRef { String = new() { Value = v } },
                 bool v => new ValueRef { Bool = new() { Value = v } },
-                _ => throw new NotSupportedException($"Cannot geenrate contracts for constant of type {val.GetType()}."),
+                _ => throw new NotSupportedException($"Cannot generate contracts for constant of type {val.GetType()}."),
             };
         }
     }

--- a/src/LeanCode.ContractsGenerator/TypeRefFactory.cs
+++ b/src/LeanCode.ContractsGenerator/TypeRefFactory.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 
 namespace LeanCode.ContractsGenerator
@@ -89,10 +87,8 @@ namespace LeanCode.ContractsGenerator
                 { ContainingNamespace: { Name: "System" }, Name: "Guid" } => New(KnownType.Guid),
                 { ContainingNamespace: { Name: "System" }, Name: "Uri" } => New(KnownType.Uri),
                 { ContainingNamespace: { Name: "System" }, Name: "TimeSpan" } => New(KnownType.TimeSpan),
-                {
-                    ContainingNamespace: { Name: "CQRS", ContainingNamespace: { Name: "LeanCode" } }, Name: "CommandResult"
-                }
-                    => New(KnownType.CommandResult),
+                { ContainingNamespace: { Name: "CQRS", ContainingNamespace: { Name: "LeanCode" } }, Name: "CommandResult" } =>
+                    New(KnownType.CommandResult),
 
                 _ when contracts.Types.IsQueryType(ts) =>
                 New(KnownType.Query, From(contracts.Types.ExtractQueryResult(ts))),


### PR DESCRIPTION
Loading projects is now done using Roslyn's `MSBuildWorkspace` which in turn uses latest MSBuild available out of all .NET SDKs installed on the machine. To simplify metadata reference management, reference assemblies are now shipped with the generator itself (see `PreserveCompilationContext` [MSBuild property](https://docs.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#preservecompilationcontext)). As an upside, handling of MSBuild projects is now a little more predictable.

In the process, we have also lost the ability to ensure that analyzed projects don't reference any unsupported package. I _think_ it should be possible to restore this check somehow, but I wasted quite a bit of time on that already and I'm not exactly willing to continue.

Some tests can no longer be run in parallel in the same process because MSBuild will _change the working directory of the entire process_ while processing projects/solutions. MSBuild itself can handle parallel builds because it actually uses multiple processes and not just multiple threads, but xunit doesn't know that. 

Fixes #36.