### PR TITLE
Create nuget package on release also

### DIFF
--- a/src/LeanCode.ContractsGenerator.Tests/LeanCode.ContractsGenerator.Tests.csproj
+++ b/src/LeanCode.ContractsGenerator.Tests/LeanCode.ContractsGenerator.Tests.csproj
@@ -8,7 +8,7 @@
 
   <Target Name="PackDependencies" BeforeTargets="Build" Condition="'$(IsInnerBuild)' != 'true'">
     <MSBuild Projects="../LeanCode.Contracts/LeanCode.Contracts.csproj" Properties="Configuration=Debug" Targets="Restore" />
-    <MSBuild Projects="../LeanCode.Contracts/LeanCode.Contracts.csproj" Properties="Configuration=Debug" Targets="Build;Pack" />
+    <MSBuild Projects="../LeanCode.Contracts/LeanCode.Contracts.csproj" Targets="Build;Pack" />
   </Target>
 
   <ItemGroup>


### PR DESCRIPTION
Release action failed due to the fact that in release configuration package was not generated causing tests to fail.