### PR TITLE
Fix release tests v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           BUILD_VERSION: ${{ steps.get_version.outputs.version }}
         run: dotnet build --no-restore --configuration Release
       - name: Test
-        run: dotnet test --no-build --configuration Release
+        run: dotnet test --configuration Release
       - name: Publish
         env:
           BUILD_VERSION: ${{ steps.get_version.outputs.version }}

--- a/src/LeanCode.ContractsGenerator.Tests/LeanCode.ContractsGenerator.Tests.csproj
+++ b/src/LeanCode.ContractsGenerator.Tests/LeanCode.ContractsGenerator.Tests.csproj
@@ -20,6 +20,10 @@
       <Link>examples/%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="../LeanCode.Contracts/bin/Release/LeanCode.Contracts.*.nupkg">
+      <Link>examples/%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Yet another fix. Previous one did not resolve the issue, this one I checked and it should be working. Looks like `--no-build` flag on `dotnet test` command somehow made local nuget package not available in tests.