### PR TITLE
Fix V3: Use $(Version) in examples/project instead of 0.0.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
           BUILD_VERSION: ${{ steps.get_version.outputs.version }}
         run: dotnet build --no-restore --configuration Release
       - name: Test
+        env:
+          BUILD_VERSION: ${{ steps.get_version.outputs.version }}
         run: dotnet test --configuration Release
       - name: Publish
         env:

--- a/examples/project/aggregated/A/A.csproj
+++ b/examples/project/aggregated/A/A.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LeanCode.Contracts" Version="0.0.1" />
+    <PackageReference Include="LeanCode.Contracts" Version="$(Version)" />
   </ItemGroup>
 
 </Project>

--- a/examples/project/aggregated/B/B.csproj
+++ b/examples/project/aggregated/B/B.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LeanCode.Contracts" Version="0.0.1" />
+    <PackageReference Include="LeanCode.Contracts" Version="$(Version)" />
   </ItemGroup>
 
 </Project>

--- a/examples/project/aggregated/C/C.csproj
+++ b/examples/project/aggregated/C/C.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LeanCode.Contracts" Version="0.0.1" />
+    <PackageReference Include="LeanCode.Contracts" Version="$(Version)" />
   </ItemGroup>
 
 </Project>

--- a/examples/project/packagereference/packagereference.csproj
+++ b/examples/project/packagereference/packagereference.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LeanCode.Contracts" Version="0.0.1" />
+    <PackageReference Include="LeanCode.Contracts" Version="$(Version)" />
     <PackageReference Include="Dapper" Version="2.0.123" />
   </ItemGroup>
 

--- a/examples/project/referencetoembedded/referencetoembedded.csproj
+++ b/examples/project/referencetoembedded/referencetoembedded.csproj
@@ -10,7 +10,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="embedded" Version="0.0.1" />
+    <PackageReference Include="embedded" Version="$(Version)" />
   </ItemGroup>
 
 </Project>

--- a/examples/project/single/single.csproj
+++ b/examples/project/single/single.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LeanCode.Contracts" Version="0.0.1" />
+    <PackageReference Include="LeanCode.Contracts" Version="$(Version)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This time I even downloaded tool to run github actions locally to check this out. `BUILD_VERSION` speficed by tag was overriding 0.0.1 default version of locally created package `LeanCode.Contracts` and nuget could not find locally `0.0.1` version as `3.0.0-alpha.1` existed instead. So it took `1.0.0` from web. Here is where this version was being set in `Directory.Build.props`: 
```
    <Version Condition="$(Version) == '' And '$(BUILD_VERSION)' != ''">$(BUILD_VERSION)</Version>
    <Version Condition="$(Version) == '' And '$(BUILD_VERSION)' == ''">0.0.1</Version>
```
Should be fine now (finally) as building, testing, publishing and packaging steps run fine locally.