### PR TITLE
Add dotnet 6 setup action to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           lfs: true
+      - name: Setup .NET 6.0
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 6.0.x
       - name: Setup .NET 7.0
         uses: actions/setup-dotnet@v3
         with:


### PR DESCRIPTION
:hurtrealbad::hurtrealbad::hurtrealbad: Hopefully this fixes those tests once for all. Earlier dotnet 6 tests did not run locally (only dotnet 7 ones) but they did on github so I thought that the library to run actions locally might have been the reason for that. With this change everything passes locally. If I get again `System.IO.FileLoadException` on some dotnet 6 tests when action is run on github I will be sad :cold_sweat:.