### PR TITLE
Write full CompilationFailedException message to stderr

### DIFF
--- a/src/LeanCode.ContractsGenerator/Program.cs
+++ b/src/LeanCode.ContractsGenerator/Program.cs
@@ -124,14 +124,8 @@ internal class Program
         catch (CompilationFailedException ex)
         {
             await Console.Error.WriteLineAsync(
-                "Cannot compile contracts. There were errors during project compilation:"
+                $"Cannot compile contracts. There were errors during project compilation: {ex.Message}"
             );
-            foreach (var d in ex.Diagnostics)
-            {
-                await Console.Error.WriteLineAsync(
-                    $"[{d.Severity}] {d.GetMessage()} at {FormatLocation(d.Location)}"
-                );
-            }
 
             return 3;
         }


### PR DESCRIPTION
`CompilationFailedException` already formats a ready `Exception.Message`, but `Program.cs` only ever printed the diagnostics which were sometimes empty and would lead to an empty error message:

<img width="932" alt="image" src="https://github.com/leancodepl/contractsgenerator/assets/29288116/d57935ed-de2c-4296-a0e0-91a8e0b63ddf">
