### PR TITLE
Add ability to not rely on custom build of `LeanCode.Contracts` in tests

### DIFF
--- a/examples/project/Directory.Build.targets
+++ b/examples/project/Directory.Build.targets
@@ -1,0 +1,20 @@
+<Project>
+
+  <!--
+    To enable out-of-this-repository tests, we need to rely on internally-built contracts only during our tests.
+    If anyone else wants to run these, they should be able to do so with a public NuGet package.
+
+    Since we don't really want to change generator API just for tests (which would be quite painful even if we wanted
+    to), we rely on environment variables that mark that we are running in the inner test suite and we have the
+    `LeanCode.Contracts` package already built.
+  -->
+
+  <ItemGroup Condition=" '$(UseTestBuildOfContracts)' == 'true' ">
+    <PackageReference Update="LeanCode.Contracts" Version="9.9.9.9-internal" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(UseTestBuildOfContracts)' != 'true' ">
+    <PackageReference Update="LeanCode.Contracts" Version="2.0.0-preview.3" />
+  </ItemGroup>
+
+</Project>

--- a/examples/project/aggregated/A/A.csproj
+++ b/examples/project/aggregated/A/A.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LeanCode.Contracts" Version="9.9.9.9-internal" />
+    <PackageReference Include="LeanCode.Contracts" />
   </ItemGroup>
 
 </Project>

--- a/examples/project/aggregated/B/B.csproj
+++ b/examples/project/aggregated/B/B.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LeanCode.Contracts" Version="9.9.9.9-internal" />
+    <PackageReference Include="LeanCode.Contracts" />
   </ItemGroup>
 
 </Project>

--- a/examples/project/aggregated/C/C.csproj
+++ b/examples/project/aggregated/C/C.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LeanCode.Contracts" Version="9.9.9.9-internal" />
+    <PackageReference Include="LeanCode.Contracts" />
   </ItemGroup>
 
 </Project>

--- a/examples/project/implicitusings/implicitusings.csproj
+++ b/examples/project/implicitusings/implicitusings.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LeanCode.Contracts" Version="9.9.9.9-internal" />
+    <PackageReference Include="LeanCode.Contracts" />
   </ItemGroup>
 
 </Project>

--- a/examples/project/packagereference/packagereference.csproj
+++ b/examples/project/packagereference/packagereference.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LeanCode.Contracts" Version="9.9.9.9-internal" />
+    <PackageReference Include="LeanCode.Contracts" />
     <PackageReference Include="Dapper" Version="2.0.123" />
   </ItemGroup>
 

--- a/examples/project/referencetoembedded/referencetoembedded.csproj
+++ b/examples/project/referencetoembedded/referencetoembedded.csproj
@@ -10,7 +10,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="LeanCode.Contracts" Version="9.9.9.9-internal" />
+    <PackageReference Include="LeanCode.Contracts" />
     <PackageReference Include="embedded" Version="8.8.8.8-internal" />
   </ItemGroup>
 

--- a/examples/project/single/single.csproj
+++ b/examples/project/single/single.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LeanCode.Contracts" Version="9.9.9.9-internal" />
+    <PackageReference Include="LeanCode.Contracts" />
   </ItemGroup>
 
 </Project>

--- a/src/LeanCode.ContractsGenerator.Tests/ExampleBasedHelpers.cs
+++ b/src/LeanCode.ContractsGenerator.Tests/ExampleBasedHelpers.cs
@@ -24,6 +24,9 @@ public static class ExampleBasedHelpers
 
     public static AssertedExport ProjectCompiles(this string path)
     {
+        // See `/examples/Directory.Build.targets` for an explanation why we need to set the variable
+        Environment.SetEnvironmentVariable("UseTestBuildOfContracts", "true");
+
         return ProjectsCompile(path);
     }
 

--- a/src/LeanCode.ContractsGenerator.Tests/ExampleBasedHelpers.cs
+++ b/src/LeanCode.ContractsGenerator.Tests/ExampleBasedHelpers.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using LeanCode.ContractsGenerator.Compilation;
 using Microsoft.Extensions.FileSystemGlobbing;
 
@@ -5,6 +6,15 @@ namespace LeanCode.ContractsGenerator.Tests;
 
 public static class ExampleBasedHelpers
 {
+    private static readonly ImmutableDictionary<string, string> TestProjectProperties =
+        ImmutableDictionary.CreateRange(
+            new Dictionary<string, string>
+            {
+                // See `/examples/project/Directory.Build.targets` for an explanation why we need to set the variable
+                ["UseTestBuildOfContracts"] = "true",
+            }
+        );
+
     public static AssertedExport Compiles(this string path)
     {
         var code = File.ReadAllText(Path.Join("examples", path));
@@ -24,9 +34,6 @@ public static class ExampleBasedHelpers
 
     public static AssertedExport ProjectCompiles(this string path)
     {
-        // See `/examples/Directory.Build.targets` for an explanation why we need to set the variable
-        Environment.SetEnvironmentVariable("UseTestBuildOfContracts", "true");
-
         return ProjectsCompile(path);
     }
 
@@ -35,7 +42,7 @@ public static class ExampleBasedHelpers
         var projectPaths = paths.Select(p => Path.Join("examples", p));
         // HACK: The sync execution results in much cleaner tests
         var (compiled, external) = ContractsCompiler
-            .CompileProjectsAsync(projectPaths)
+            .CompileProjectsAsync(projectPaths, TestProjectProperties)
             .GetAwaiter()
             .GetResult();
         return new(

--- a/src/LeanCode.ContractsGenerator/Compilation/ContractsCompiler.cs
+++ b/src/LeanCode.ContractsGenerator/Compilation/ContractsCompiler.cs
@@ -80,12 +80,22 @@ public static class ContractsCompiler
             .Select(path => MetadataReference.CreateFromFile(path))
             .ToImmutableList();
 
+    public static Task<(CompiledContracts Compiled, List<Export> External)> CompileProjectsAsync(
+        IEnumerable<string> projectPaths
+    )
+    {
+        return CompileProjectsAsync(projectPaths, ImmutableDictionary<string, string>.Empty);
+    }
+
     public static async Task<(
         CompiledContracts Compiled,
         List<Export> External
-    )> CompileProjectsAsync(IEnumerable<string> projectPaths)
+    )> CompileProjectsAsync(
+        IEnumerable<string> projectPaths,
+        ImmutableDictionary<string, string> properties
+    )
     {
-        using var loader = new ProjectLoader();
+        using var loader = new ProjectLoader(properties);
         await loader.LoadProjectsAsync(projectPaths);
         var compilations = await loader.CompileAsync();
         var compiledContracts = Compile(

--- a/src/LeanCode.ContractsGenerator/Compilation/MSBuild/MSBuildHelper.cs
+++ b/src/LeanCode.ContractsGenerator/Compilation/MSBuild/MSBuildHelper.cs
@@ -50,9 +50,10 @@ public static class MSBuildHelper
         }
     }
 
-    public static MSBuildWorkspace CreateWorkspace()
+    public static MSBuildWorkspace CreateWorkspace(ImmutableDictionary<string, string> properties)
     {
-        return MSBuildWorkspace.Create(GlobalProperties);
+        var finalProps = properties.AddRange(GlobalProperties);
+        return MSBuildWorkspace.Create(finalProps);
     }
 
     public static int RestoreProjects(IReadOnlyCollection<string> projectPaths)

--- a/src/LeanCode.ContractsGenerator/Compilation/ProjectLoader.cs
+++ b/src/LeanCode.ContractsGenerator/Compilation/ProjectLoader.cs
@@ -1,5 +1,5 @@
+using System.Collections.Immutable;
 using LeanCode.ContractsGenerator.Compilation.MSBuild;
-using Microsoft.Build.Logging;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.MSBuild;
@@ -8,8 +8,13 @@ namespace LeanCode.ContractsGenerator.Compilation;
 
 public sealed class ProjectLoader : IDisposable
 {
-    private readonly MSBuildWorkspace msbuildWorkspace = MSBuildHelper.CreateWorkspace();
     private readonly List<Project> projects = new();
+    private readonly MSBuildWorkspace msbuildWorkspace;
+
+    public ProjectLoader(ImmutableDictionary<string, string> properties)
+    {
+        msbuildWorkspace = MSBuildHelper.CreateWorkspace(properties);
+    }
 
     public async Task LoadProjectsAsync(IEnumerable<string> projectPaths)
     {


### PR DESCRIPTION
Oh boi, this is ugly, but I have no other idea how to achieve this.