### PR TITLE
[CORELIB-356] - Add a test case for array parameters in attributes

### DIFF
--- a/examples/attributes/authorize_when_array_params.cs
+++ b/examples/attributes/authorize_when_array_params.cs
@@ -1,0 +1,8 @@
+using LeanCode.Contracts;
+using LeanCode.Contracts.Security;
+
+[AuthorizeWhenHasAnyOf(new[] { "P1", "P2" })]
+public class A : ICommand { }
+
+[AuthorizeWhenHasAnyOf("P1", "P2")]
+public class B : ICommand { }

--- a/src/LeanCode.ContractsGenerator.Tests/ExampleBased/Attributes.cs
+++ b/src/LeanCode.ContractsGenerator.Tests/ExampleBased/Attributes.cs
@@ -70,4 +70,23 @@ public class Attributes
             .WithDto("AuthorizeWhenCustomGenericAttribute")
             .ThatExtends(Known(KnownType.AuthorizeWhenAttribute));
     }
+
+    [Fact]
+    public void AuthorizeWhen_array_params()
+    {
+        "attributes/authorize_when_array_params.cs"
+            .Compiles()
+            .WithCommand("A")
+            .WithAttribute(
+                "LeanCode.Contracts.Security.AuthorizeWhenHasAnyOfAttribute",
+                Positional(0, "P1"),
+                Positional(1, "P2")
+            )
+            .WithCommand("B")
+            .WithAttribute(
+                "LeanCode.Contracts.Security.AuthorizeWhenHasAnyOfAttribute",
+                Positional(0, "P1"),
+                Positional(1, "P2")
+            );
+    }
 }


### PR DESCRIPTION
The issue as reported seems to be fixed (it was on the older generator version and I cannot reproduce). Still leaving a test case to leave a trace