### PR TITLE
Fix ABI break in ValidationError's constructors

### DIFF
--- a/src/LeanCode.Contracts/Validation/ValidationError.cs
+++ b/src/LeanCode.Contracts/Validation/ValidationError.cs
@@ -1,7 +1,11 @@
 namespace LeanCode.Contracts.Validation;
 
-public class ValidationError(string propertyName, string errorMessage, int errorCode, string? errorName = null)
+[method: System.Text.Json.Serialization.JsonConstructor]
+public class ValidationError(string propertyName, string errorMessage, int errorCode, string? errorName)
 {
+    public ValidationError(string propertyName, string errorMessage, int errorCode)
+        : this(propertyName, errorMessage, errorCode, null) { }
+
     public string PropertyName { get; } = propertyName;
     public string ErrorMessage { get; } = errorMessage;
     public int ErrorCode { get; } = errorCode;

--- a/src/LeanCode.ContractsGenerator.Tests/Abi/ValidationErrorAbiTests.cs
+++ b/src/LeanCode.ContractsGenerator.Tests/Abi/ValidationErrorAbiTests.cs
@@ -1,0 +1,21 @@
+using LeanCode.Contracts.Validation;
+using Xunit;
+
+namespace LeanCode.ContractsGenerator.Tests.Abi;
+
+public class ValidationErrorAbiTests
+{
+    [Fact]
+    public void ValidationError_has_3_params_ctor()
+    {
+        Assert.NotNull(typeof(ValidationError).GetConstructor([typeof(string), typeof(string), typeof(int)]));
+    }
+
+    [Fact]
+    public void ValidationError_has_4_params_ctor()
+    {
+        Assert.NotNull(
+            typeof(ValidationError).GetConstructor([typeof(string), typeof(string), typeof(int), typeof(string)])
+        );
+    }
+}


### PR DESCRIPTION
Optional parameters in public APIs strike again :disappointed: